### PR TITLE
Show final overall stats at end of transfer (fix #7)

### DIFF
--- a/src/ui/inline.rs
+++ b/src/ui/inline.rs
@@ -169,7 +169,16 @@ impl ProgressRenderer for InlineProgress {
     }
 
     fn finish(&mut self) -> io::Result<()> {
+        // Print a final overall summary (useful for logs / scrolling terminals)
+        let elapsed = self.data.elapsed();
+        let avg_bps = self.data.average_bytes_per_sec().unwrap_or(0.0);
         println!();
+        println!(
+            "Done: {} in {:.1}s | avg {}/s",
+            format_bytes(self.data.current_bytes as f64),
+            elapsed.as_secs_f64(),
+            format_bytes(avg_bps)
+        );
         Ok(())
     }
 }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -6,9 +6,12 @@ pub struct ProgressData {
     pub current_file: String,
     pub current_file_size: u64,
     pub current_file_progress: u64,
+
+    pub start_time: Instant,
     pub last_update: Instant,
     pub last_bytes: u64,
     pub last_speed: f64,
+
     pub operation_type: String,
     pub items_total: Option<usize>, // Total number of items to process
     pub items_processed: usize,     // Number of items processed
@@ -23,9 +26,12 @@ impl ProgressData {
             current_file: String::new(),
             current_file_size: 0,
             current_file_progress: 0,
+
+            start_time: now,
             last_update: now,
             last_bytes: 0,
             last_speed: 0.0,
+
             operation_type: String::new(),
             items_total: None,
             items_processed: 0,
@@ -68,5 +74,17 @@ impl ProgressData {
         }
         let secs = (remaining_bytes / bytes_per_sec).ceil() as u64;
         Some(Duration::from_secs(secs))
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.start_time.elapsed()
+    }
+
+    pub fn average_bytes_per_sec(&self) -> Option<f64> {
+        let secs = self.elapsed().as_secs_f64();
+        if secs <= 0.0 {
+            return None;
+        }
+        Some(self.current_bytes as f64 / secs)
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -219,18 +219,18 @@ impl TuiProgress {
                 )?;
                 write!(out, "{} ", vertical)?;
                 execute!(out, SetForegroundColor(text_color))?;
-                
+
                 // box_width - 2 (borders) - 1 (left space) -> max content width
                 let available_width = box_width.saturating_sub(3); // -2 borders, -1 left space
-                let content_len = content.chars().count(); 
+                let content_len = content.chars().count();
                 let display_content = if content_len > available_width {
                     &content[..available_width]
                 } else {
                     content
                 };
-                
+
                 write!(out, "{}", display_content)?;
-                
+
                 let padding = available_width.saturating_sub(display_content.chars().count());
                 if padding > 0 {
                     write!(out, "{}", " ".repeat(padding))?;
@@ -421,6 +421,16 @@ impl ProgressRenderer for TuiProgress {
             self.raw_mode_enabled = false;
             println!();
         }
+
+        // Print a final overall summary line
+        let elapsed = self.data.elapsed();
+        let avg_bps = self.data.average_bytes_per_sec().unwrap_or(0.0);
+        println!(
+            "Done: {} in {:.1}s | avg {}/s",
+            format_bytes(self.data.current_bytes as f64),
+            elapsed.as_secs_f64(),
+            format_bytes(avg_bps)
+        );
 
         self.finished = true;
         Ok(())


### PR DESCRIPTION
Implements a final summary line after completion (elapsed time + average throughput), similar to rsync --info=progress2.\n\nFixes #7.