### PR TITLE
Handle Ctrl+Z suspend/resume for TUI (fix #4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "reflink-copy",
  "regex",
  "serde",
+ "signal-hook",
  "terminal_size",
  "thiserror 2.0.17",
  "tokio",
@@ -1527,9 +1528,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ regex = "1.12.2"
 blake3 = "1.5"
 reflink-copy = "0.1.28"
 
+signal-hook = "0.3.18"
+
 [profile.release]
 codegen-units = 1
 lto = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -295,15 +295,15 @@ impl Commands {
     }
 
     // Split -> (sources, dest)
-    pub fn get_sources_and_dest(&self) -> (&[PathBuf], &PathBuf) {
+    pub fn get_sources_and_dest(&self) -> std::result::Result<(&[PathBuf], &PathBuf), String> {
         match self {
             Commands::Copy { paths, .. } | Commands::Move { paths, .. } => {
                 let (dest, sources) = paths
                     .split_last()
-                    .expect("Clap should ensure at least 2 args");
-                (sources, dest)
+                    .ok_or_else(|| "missing source/destination arguments".to_string())?;
+                Ok((sources, dest))
             }
-            _ => panic!("Command does not have source/dest structure"),
+            _ => Err("command does not have source/destination structure".to_string()),
         }
     }
 
@@ -395,10 +395,10 @@ impl Commands {
         }
     }
 
-    pub fn get_remove_paths(&self) -> Option<&Vec<PathBuf>> {
+    pub fn get_remove_paths(&self) -> std::result::Result<&Vec<PathBuf>, String> {
         match self {
-            Commands::Remove { paths, .. } => Some(paths),
-            _ => None,
+            Commands::Remove { paths, .. } => Ok(paths),
+            _ => Err("command does not support remove paths".to_string()),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,9 @@ async fn confirm_removal(files: &[commands::remove::FileToRemove]) -> Result<boo
 async fn handle_copy_command(args: &Commands) -> Result<()> {
     let test_mode = args.get_test_mode();
     let excludes = args.compile_excludes()?;
-    let (sources, dest) = args.get_sources_and_dest();
+    let (sources, dest) = args
+        .get_sources_and_dest()
+        .map_err(anyhow::Error::msg)?;
 
     // Validation
     if let Some(mode) = args.get_reflink_mode() {
@@ -229,7 +231,9 @@ async fn handle_copy_command(args: &Commands) -> Result<()> {
 async fn handle_move_command(args: &Commands) -> Result<()> {
     let test_mode = args.get_test_mode();
     let excludes = args.compile_excludes()?;
-    let (sources, dest) = args.get_sources_and_dest();
+    let (sources, dest) = args
+        .get_sources_and_dest()
+        .map_err(anyhow::Error::msg)?;
 
     if sources.len() > 1 && (!dest.exists() || !dest.is_dir()) {
         bail!(
@@ -341,7 +345,7 @@ async fn handle_move_command(args: &Commands) -> Result<()> {
 async fn handle_remove_command(args: &Commands) -> Result<()> {
     let test_mode = args.get_test_mode();
     let excludes = args.compile_excludes()?;
-    let paths = args.get_remove_paths().unwrap();
+    let paths = args.get_remove_paths().map_err(anyhow::Error::msg)?;
 
     let files_to_remove =
         commands::remove::check_removes(paths, args.is_recursive(), args, &excludes).await?;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,3 +4,4 @@ pub mod state;
 pub mod tui;
 pub mod inline;
 pub mod display;
+pub mod suspend;

--- a/src/ui/suspend.rs
+++ b/src/ui/suspend.rs
@@ -1,0 +1,38 @@
+use signal_hook::consts::signal::{SIGCONT, SIGTSTP};
+use signal_hook::iterator::Signals;
+use std::io;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+
+#[derive(Debug, Clone, Copy)]
+pub enum SuspendEvent {
+    Suspend,
+    Continue,
+}
+
+/// Install a background thread that forwards SIGTSTP/SIGCONT into a channel.
+///
+/// Intended for use by the TUI renderer to gracefully reset terminal state on Ctrl+Z
+/// and resume appropriately on fg/bg.
+pub fn install_signal_forwarder() -> io::Result<Receiver<SuspendEvent>> {
+    let (tx, rx) = mpsc::channel();
+
+    let mut signals =
+        Signals::new([SIGTSTP, SIGCONT]).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+    thread::spawn(move || {
+        for sig in signals.forever() {
+            match sig {
+                SIGTSTP => {
+                    let _ = tx.send(SuspendEvent::Suspend);
+                }
+                SIGCONT => {
+                    let _ = tx.send(SuspendEvent::Continue);
+                }
+                _ => {}
+            }
+        }
+    });
+
+    Ok(rx)
+}


### PR DESCRIPTION
Implements graceful suspend (Ctrl+Z) and resume (fg/bg) handling for the TUI renderer:\n\n- On SIGTSTP: disables raw mode + shows cursor, then stops the process (SIGSTOP).\n- On SIGCONT: detects foreground/background via tcgetpgrp(); restores TUI if foreground, stays silent if background.\n\nFixes #4.