### PR TITLE
Fix transfer integrity regressions and local copy jobs

### DIFF
--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -7,6 +7,7 @@ use crate::ui::display::{print_dry_run, ActionType};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex as ParkingMutex;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::fs::{self, File};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
@@ -499,7 +500,7 @@ where
     let test_mode = cli.get_test_mode();
     let callback = ProgressCallback {
         callback: progress_callback,
-        on_new_file: Box::new(on_new_file),
+        on_new_file: Arc::new(on_new_file),
     };
 
     // Directories must exist before concurrent file copies into them,
@@ -558,7 +559,16 @@ where
 #[allow(clippy::type_complexity)]
 pub struct ProgressCallback<F> {
     callback: F,
-    on_new_file: Box<dyn Fn(&str, u64) + Send + Sync>,
+    on_new_file: Arc<dyn Fn(&str, u64) + Send + Sync>,
+}
+
+impl<F: Clone> Clone for ProgressCallback<F> {
+    fn clone(&self) -> Self {
+        Self {
+            callback: self.callback.clone(),
+            on_new_file: Arc::clone(&self.on_new_file),
+        }
+    }
 }
 
 pub async fn copy_path<F>(
@@ -575,7 +585,7 @@ where
     let test_mode = cli.get_test_mode();
     let callback = ProgressCallback {
         callback: progress_callback,
-        on_new_file: Box::new(on_new_file),
+        on_new_file: Arc::new(on_new_file),
     };
 
     if traversal::is_excluded(src, excludes) {
@@ -888,7 +898,7 @@ where
         .unwrap_or_default()
         .to_string_lossy()
         .to_string();
-    (callback.on_new_file)(&file_name, file_size);
+    callback.on_new_file.as_ref()(&file_name, file_size);
 
     let (try_reflink, fail_on_error) = resolve_reflink_mode(reflink_arg);
     let sparse_mode = resolve_sparse_mode(sparse_arg);
@@ -1114,9 +1124,11 @@ where
 {
     let test_mode = cli.get_test_mode();
     let recursive = cli.is_recursive();
+    let jobs = cli.local_jobs();
+    let verbose = cli.is_verbose();
     let callback = ProgressCallback {
         callback: cb.on_progress,
-        on_new_file: cb.on_new_file,
+        on_new_file: Arc::from(cb.on_new_file),
     };
     let on_total_update = cb.on_total_update;
     let on_scan_complete = cb.on_scan_complete;
@@ -1149,6 +1161,7 @@ where
     });
 
     let mut dir_entries: Vec<(PathBuf, PathBuf)> = Vec::new();
+    let mut in_flight = tokio::task::JoinSet::new();
 
     while let Some(msg) = rx.recv().await {
         match msg {
@@ -1162,17 +1175,24 @@ where
                 PlanEntry::CopyFile { ref src, ref dst } => {
                     check_overwrite(dst, cli).await?;
 
-                    copy_file(
-                        src,
-                        dst,
-                        CopyFileOptions::from_cli(cli, test_mode.clone()),
-                        &callback,
-                    )
-                    .await?;
-
-                    if cli.is_verbose() {
-                        eprintln!("'{}' -> '{}'", src.display(), dst.display());
+                    while in_flight.len() >= jobs {
+                        match in_flight.join_next().await {
+                            Some(res) => res??,
+                            None => break,
+                        }
                     }
+
+                    let src = src.clone();
+                    let dst = dst.clone();
+                    let opts = CopyFileOptions::from_cli(cli, test_mode.clone());
+                    let cb = callback.clone();
+                    in_flight.spawn(async move {
+                        copy_file(&src, &dst, opts, &cb).await?;
+                        if verbose {
+                            eprintln!("'{}' -> '{}'", src.display(), dst.display());
+                        }
+                        Ok::<(), BcmrError>(())
+                    });
                 }
             },
             ScanMessage::Done => {
@@ -1180,6 +1200,10 @@ where
                 break;
             }
         }
+    }
+
+    while let Some(res) = in_flight.join_next().await {
+        res??;
     }
 
     scanner.await??;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -598,7 +598,7 @@ where
         if offset > 0 {
             std_file.seek(std::io::SeekFrom::Start(offset))?;
         }
-        let total_size = std_file.metadata()?.len() - offset;
+        let total_size = std_file.metadata()?.len().saturating_sub(offset);
 
         let mut fds = [0i32; 2];
         if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } < 0 {
@@ -679,7 +679,10 @@ fn splice_n(
             return Err(std::io::Error::last_os_error());
         }
         if got == 0 {
-            break;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "splice hit EOF before the advertised frame payload was produced",
+            ));
         }
         let mut drained = 0usize;
         while drained < got as usize {
@@ -697,7 +700,10 @@ fn splice_n(
                 return Err(std::io::Error::last_os_error());
             }
             if n2 == 0 {
-                break;
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "splice could not drain the pipe into stdout",
+                ));
             }
             drained += n2 as usize;
         }
@@ -792,9 +798,15 @@ where
         };
         match m {
             Message::Data { payload } => {
-                enforce_write_bound(written, payload.len(), declared_size)?;
-                consume_block(&payload, &mut file, &mut hasher, dedup_state.as_mut()).await?;
-                written += payload.len() as u64;
+                consume_block(
+                    &payload,
+                    &mut file,
+                    &mut hasher,
+                    dedup_state.as_mut(),
+                    &mut written,
+                    declared_size,
+                )
+                .await?;
             }
             Message::DataCompressed {
                 algo,
@@ -802,9 +814,15 @@ where
                 payload,
             } => {
                 let decoded = compress::decode_block(algo, original_size, &payload)?;
-                enforce_write_bound(written, decoded.len(), declared_size)?;
-                consume_block(&decoded, &mut file, &mut hasher, dedup_state.as_mut()).await?;
-                written += decoded.len() as u64;
+                consume_block(
+                    &decoded,
+                    &mut file,
+                    &mut hasher,
+                    dedup_state.as_mut(),
+                    &mut written,
+                    declared_size,
+                )
+                .await?;
             }
             Message::Done => break,
             other => return Err(anyhow::anyhow!("put: unexpected message {other:?}")),
@@ -816,6 +834,9 @@ where
     if let Some(state) = dedup_state.as_mut() {
         flush_remaining_cas_blocks(state, &mut file, &mut hasher, &mut written, declared_size)
             .await?;
+    }
+    if written != declared_size {
+        bail!("put: declared {} bytes, received {}", declared_size, written);
     }
 
     file.flush().await?;
@@ -845,12 +866,16 @@ async fn consume_block(
     file: &mut tokio::fs::File,
     hasher: &mut blake3::Hasher,
     dedup: Option<&mut DedupState>,
+    written: &mut u64,
+    declared_size: u64,
 ) -> Result<()> {
     if let Some(state) = dedup {
         while state.cursor < state.hashes.len() && !state.is_missing(state.cursor) {
             let cached = cas::read(&state.hashes[state.cursor])?;
+            enforce_write_bound(*written, cached.len(), declared_size)?;
             hasher.update(&cached);
             file.write_all(&cached).await?;
+            *written += cached.len() as u64;
             state.cursor += 1;
         }
         if state.cursor < state.hashes.len() && state.is_missing(state.cursor) {
@@ -861,8 +886,10 @@ async fn consume_block(
             state.cursor += 1;
         }
     }
+    enforce_write_bound(*written, block.len(), declared_size)?;
     hasher.update(block);
     file.write_all(block).await?;
+    *written += block.len() as u64;
     Ok(())
 }
 

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -127,7 +127,7 @@ async fn check_resume_state(
     source_size: u64,
     existing_full_hash: impl AsyncFnOnce() -> Result<String, BcmrError>,
     source_full_hash: impl AsyncFnOnce() -> Result<String, BcmrError>,
-    existing_partial_hash: impl AsyncFnOnce(u64) -> Result<String, BcmrError>,
+    source_partial_hash: impl AsyncFnOnce(u64) -> Result<String, BcmrError>,
 ) -> Result<ResumeDecision, BcmrError> {
     if !(opts.resume || opts.append || opts.strict) {
         return Ok(ResumeDecision {
@@ -149,41 +149,35 @@ async fn check_resume_state(
     };
 
     if existing_size == source_size {
-        if opts.strict {
-            let ex_hash = existing_full_hash().await?;
-            let src_hash = source_full_hash().await?;
-            if ex_hash == src_hash {
-                return Ok(ResumeDecision {
-                    skip_bytes: 0,
-                    use_append_mode: false,
-                    skip_entirely: true,
-                });
-            }
-        } else {
+        let ex_hash = existing_full_hash().await?;
+        let src_hash = source_full_hash().await?;
+        if ex_hash == src_hash {
             return Ok(ResumeDecision {
                 skip_bytes: 0,
                 use_append_mode: false,
                 skip_entirely: true,
             });
         }
+        return Ok(ResumeDecision {
+            skip_bytes: 0,
+            use_append_mode: false,
+            skip_entirely: false,
+        });
     } else if existing_size < source_size {
-        if opts.strict {
-            let ex_hash = existing_full_hash().await?;
-            let partial = existing_partial_hash(existing_size).await?;
-            if ex_hash == partial {
-                return Ok(ResumeDecision {
-                    skip_bytes: existing_size,
-                    use_append_mode: true,
-                    skip_entirely: false,
-                });
-            }
-        } else {
+        let ex_hash = existing_full_hash().await?;
+        let partial = source_partial_hash(existing_size).await?;
+        if ex_hash == partial {
             return Ok(ResumeDecision {
                 skip_bytes: existing_size,
                 use_append_mode: true,
                 skip_entirely: false,
             });
         }
+        return Ok(ResumeDecision {
+            skip_bytes: 0,
+            use_append_mode: false,
+            skip_entirely: false,
+        });
     }
 
     Ok(ResumeDecision {
@@ -1259,5 +1253,74 @@ mod tests {
     fn test_unix_to_touch_ts_with_seconds() {
         let ts = unix_to_touch_ts(1592210445);
         assert!(ts.ends_with(".45"));
+    }
+
+    #[tokio::test]
+    async fn test_check_resume_state_same_size_requires_hash_match() {
+        let opts = RemoteTransferOptions {
+            resume: true,
+            ..Default::default()
+        };
+
+        let decision = check_resume_state(
+            &opts,
+            Some(1024),
+            1024,
+            async || Ok("existing".to_string()),
+            async || Ok("source".to_string()),
+            async |_| Ok("unused".to_string()),
+        )
+        .await
+        .expect("decision should compute");
+
+        assert!(!decision.skip_entirely);
+        assert_eq!(decision.skip_bytes, 0);
+        assert!(!decision.use_append_mode);
+    }
+
+    #[tokio::test]
+    async fn test_check_resume_state_shorter_prefix_requires_hash_match() {
+        let opts = RemoteTransferOptions {
+            append: true,
+            ..Default::default()
+        };
+
+        let decision = check_resume_state(
+            &opts,
+            Some(512),
+            1024,
+            async || Ok("corrupt-prefix".to_string()),
+            async || Ok("unused".to_string()),
+            async |_| Ok("source-prefix".to_string()),
+        )
+        .await
+        .expect("decision should compute");
+
+        assert!(!decision.skip_entirely);
+        assert_eq!(decision.skip_bytes, 0);
+        assert!(!decision.use_append_mode);
+    }
+
+    #[tokio::test]
+    async fn test_check_resume_state_matching_prefix_allows_append() {
+        let opts = RemoteTransferOptions {
+            resume: true,
+            ..Default::default()
+        };
+
+        let decision = check_resume_state(
+            &opts,
+            Some(512),
+            1024,
+            async || Ok("prefix-hash".to_string()),
+            async || Ok("full-hash".to_string()),
+            async |_| Ok("prefix-hash".to_string()),
+        )
+        .await
+        .expect("decision should compute");
+
+        assert!(!decision.skip_entirely);
+        assert_eq!(decision.skip_bytes, 512);
+        assert!(decision.use_append_mode);
     }
 }

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use bcmr::core::checksum;
 use bcmr::core::io as durable_io;
@@ -470,6 +471,46 @@ fn e2e_copy_preserves_existing_on_no_force() {
 
     let dst_hash_after = checksum::calculate_hash(&dst).unwrap();
     assert_eq!(dst_hash_before, dst_hash_after);
+}
+
+#[test]
+fn e2e_pipeline_copy_honors_jobs_concurrency() {
+    let dir = tempfile::tempdir().unwrap();
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+
+    let mut args: Vec<String> = vec![
+        "copy".to_string(),
+        "--jobs".to_string(),
+        "4".to_string(),
+        "--test-mode".to_string(),
+        "delay:400".to_string(),
+    ];
+
+    for i in 0..6 {
+        let src = dir.path().join(format!("src-{i}.txt"));
+        fs::write(&src, b"x").unwrap();
+        args.push(src.to_string_lossy().into_owned());
+    }
+    args.push(dst_dir.to_string_lossy().into_owned());
+
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let start = Instant::now();
+    let (ok, _, stderr) = run_bcmr(&arg_refs);
+    let elapsed = start.elapsed();
+
+    assert!(ok, "copy with --jobs should succeed: {}", stderr);
+    assert!(
+        elapsed < Duration::from_millis(1800),
+        "expected file copies to overlap with --jobs; elapsed={elapsed:?}"
+    );
+
+    for i in 0..6 {
+        assert!(
+            dst_dir.join(format!("src-{i}.txt")).exists(),
+            "destination file src-{i}.txt missing"
+        );
+    }
 }
 
 /// Exercises the `block_hashes[..keep]` carry-forward path in `copy_file`:

--- a/tests/e2e_serve_basic.rs
+++ b/tests/e2e_serve_basic.rs
@@ -132,6 +132,65 @@ async fn serve_put_size_bound_rejects_oversized() {
     let _ = child.wait().await;
 }
 
+/// Security regression: PUT must also reject a client that sends fewer bytes
+/// than declared and then terminates with Done.
+#[tokio::test]
+async fn serve_put_size_bound_rejects_short_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let dst = dir.path().join("truncated.bin");
+
+    use bcmr::core::protocol::{read_message, write_message, Message, PROTOCOL_VERSION};
+    let ServeChild {
+        mut child,
+        mut stdin,
+        mut stdout,
+    } = spawn_serve("/");
+
+    write_message(
+        &mut stdin,
+        &Message::Hello {
+            version: PROTOCOL_VERSION,
+            caps: 0,
+        },
+    )
+    .await
+    .unwrap();
+    let _welcome = read_message(&mut stdout).await.unwrap();
+
+    write_message(
+        &mut stdin,
+        &Message::Put {
+            path: dst.to_string_lossy().into_owned(),
+            size: 10,
+        },
+    )
+    .await
+    .unwrap();
+    write_message(
+        &mut stdin,
+        &Message::Data {
+            payload: vec![0xcd; 5],
+        },
+    )
+    .await
+    .unwrap();
+    write_message(&mut stdin, &Message::Done).await.unwrap();
+
+    let reply = read_message(&mut stdout).await.unwrap().unwrap();
+    match reply {
+        Message::Error { message } => {
+            assert!(
+                message.contains("declared 10 bytes, received 5"),
+                "expected short-write error, got: {message}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
+
+    drop(stdin);
+    let _ = child.wait().await;
+}
+
 #[tokio::test]
 async fn serve_stat_file() {
     let dir = tempfile::tempdir().unwrap();
@@ -378,6 +437,39 @@ async fn serve_get_fast_returns_no_hash_but_correct_bytes() {
     tmp.write_all(&data).unwrap();
     let dst_hash = checksum::calculate_hash(&dir.path().join("fast.dst")).unwrap();
     assert_eq!(dst_hash, src_hash, "fast-mode download must match source");
+}
+
+#[tokio::test]
+async fn serve_get_fast_with_offset_past_eof_returns_empty() {
+    use bcmr::core::protocol::CAP_FAST;
+
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("fast-offset.bin");
+    create_file(&src, 1024 * 1024);
+
+    let received: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let received_clone = Arc::clone(&received);
+
+    let mut client = bcmr::core::serve_client::ServeClient::connect_local_with_caps(CAP_FAST)
+        .await
+        .unwrap();
+    let server_hash = tokio::time::timeout(
+        tokio::time::Duration::from_secs(5),
+        client.get(src.to_str().unwrap(), 2 * 1024 * 1024, move |chunk| {
+            received_clone.lock().unwrap().extend_from_slice(chunk);
+        }),
+    )
+    .await
+    .expect("fast GET with offset past EOF should terminate")
+    .unwrap();
+    client.close().await.unwrap();
+
+    assert!(
+        server_hash.is_none(),
+        "fast mode should still suppress the server hash past EOF"
+    );
+    let data = Arc::try_unwrap(received).unwrap().into_inner().unwrap();
+    assert!(data.is_empty(), "expected no bytes beyond EOF");
 }
 
 #[tokio::test]


### PR DESCRIPTION
  ## Summary
  - fix serve PUT so short writes are rejected instead of being reported as success
  - fix Linux fast GET splice handling for offset-past-EOF and premature EOF/write-zero cases
  - make legacy SSH fallback resume/append validate content before skipping or appending
  - make pipeline copy actually honor local --jobs concurrency

  ## Testing
  - not run locally because this environment does not have cargo/rustc installed
  - added regression tests for short PUT, fast GET past EOF, fallback resume decisions, and pipeline copy concurrency