### PR TITLE
fix: direct-TCP rendezvous concurrent verify + client dial timeout

### DIFF
--- a/src/commands/serve/rendezvous.rs
+++ b/src/commands/serve/rendezvous.rs
@@ -98,27 +98,39 @@ async fn run_rendezvous(
     root: PathBuf,
 ) {
     let deadline = tokio::time::Instant::now() + rendezvous_accept_timeout();
-    let authed = loop {
-        let remaining = match deadline.checked_duration_since(tokio::time::Instant::now()) {
-            Some(d) if !d.is_zero() => d,
-            _ => return,
-        };
-        let mut stream = match tokio::time::timeout(remaining, listener.accept()).await {
-            Ok(Ok((stream, _peer))) => stream,
-            Ok(Err(e)) => {
-                eprintln!("serve: direct-tcp accept failed: {e}");
-                return;
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<tokio::net::TcpStream>(1);
+
+    let authed: Option<tokio::net::TcpStream> = loop {
+        tokio::select! {
+            biased;
+            winner = rx.recv() => break winner,
+            _ = tokio::time::sleep_until(deadline) => break None,
+            accept_res = listener.accept() => match accept_res {
+                Ok((stream, _peer)) => {
+                    let sk = zeroize::Zeroizing::new(*session_key);
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        let mut stream = stream;
+                        if verify_auth_hello(&mut stream, &sk).await {
+                            let _ = tx.send(stream).await;
+                        }
+                    });
+                }
+                Err(e) => {
+                    eprintln!("serve: direct-tcp accept failed: {e}");
+                    break None;
+                }
             }
-            Err(_) => return,
-        };
-        if verify_auth_hello(&mut stream, &session_key).await {
-            break stream;
         }
     };
-    drop(listener);
 
-    if let Err(e) = run_direct_session(authed, &session_key, &root).await {
-        eprintln!("serve: direct-tcp session error: {e}");
+    drop(listener);
+    drop(tx);
+
+    if let Some(stream) = authed {
+        if let Err(e) = run_direct_session(stream, &session_key, &root).await {
+            eprintln!("serve: direct-tcp session error: {e}");
+        }
     }
 }
 

--- a/src/core/serve_client/promote.rs
+++ b/src/core/serve_client/promote.rs
@@ -7,6 +7,8 @@ use crate::core::transport::ssh as ssh_transport;
 
 use super::{ServeClient, Transport};
 
+const DIRECT_TCP_DIAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 fn auth_hello_mac(session_key: &[u8; 32], nonce: &[u8; 32]) -> blake3::Hash {
     let mut input = [0u8; AUTH_HELLO_TAG.len() + 32];
     input[..AUTH_HELLO_TAG.len()].copy_from_slice(AUTH_HELLO_TAG);
@@ -100,9 +102,14 @@ impl ServeClient {
             }
         };
 
-        let stream = match tokio::net::TcpStream::connect(&addr).await {
-            Ok(s) => s,
-            Err(e) => {
+        let stream = match tokio::time::timeout(
+            DIRECT_TCP_DIAL_TIMEOUT,
+            tokio::net::TcpStream::connect(&addr),
+        )
+        .await
+        {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => {
                 let mut msg = format!(
                     "direct-TCP dial to {addr} failed: {e}. The server bound its \
                      rendezvous listener on the interface where SSH arrived, but \
@@ -118,6 +125,12 @@ impl ServeClient {
                     }
                 }
                 return Err(BcmrError::InvalidInput(msg));
+            }
+            Err(_) => {
+                return Err(BcmrError::InvalidInput(format!(
+                    "direct-TCP dial to {addr} timed out after {}s",
+                    DIRECT_TCP_DIAL_TIMEOUT.as_secs()
+                )));
             }
         };
         let (tcp_reader, tcp_writer) = stream.into_split();

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(not(windows))]
 use std::time::{Duration, Instant};
 
 use bcmr::core::checksum;
@@ -470,6 +471,7 @@ fn e2e_copy_preserves_existing_on_no_force() {
     assert_eq!(dst_hash_before, dst_hash_after);
 }
 
+#[cfg(not(windows))]
 #[test]
 fn e2e_pipeline_copy_honors_jobs_concurrency() {
     const FILES: usize = 12;

--- a/tests/e2e_serve_direct_tcp.rs
+++ b/tests/e2e_serve_direct_tcp.rs
@@ -216,6 +216,84 @@ async fn serve_direct_tcp_squatter_does_not_starve_real_client() {
 }
 
 #[tokio::test]
+async fn serve_direct_tcp_hung_squatters_do_not_starve_real_client() {
+    use bcmr::core::protocol::{
+        read_message, write_message, Message, CAP_AEAD, CAP_DIRECT_TCP, PROTOCOL_VERSION,
+    };
+    use tokio::net::TcpStream;
+
+    let ServeChild {
+        mut child,
+        stdin: mut ssh_stdin,
+        stdout: mut ssh_stdout,
+    } = spawn_serve("/");
+
+    write_message(
+        &mut ssh_stdin,
+        &Message::Hello {
+            version: PROTOCOL_VERSION,
+            caps: CAP_DIRECT_TCP,
+        },
+    )
+    .await
+    .unwrap();
+    let _ = read_message(&mut ssh_stdout).await.unwrap();
+    write_message(&mut ssh_stdin, &Message::OpenDirectChannel)
+        .await
+        .unwrap();
+    let (addr, key) = match read_message(&mut ssh_stdout).await.unwrap().unwrap() {
+        Message::DirectChannelReady { addr, session_key } => (addr, session_key),
+        other => panic!("expected DirectChannelReady, got {other:?}"),
+    };
+
+    let mut hung = Vec::with_capacity(8);
+    for _ in 0..8 {
+        hung.push(TcpStream::connect(&addr).await.unwrap());
+    }
+
+    let start = std::time::Instant::now();
+    let real = TcpStream::connect(&addr).await.unwrap();
+    drop(ssh_stdin);
+    let (mut rr, mut rw) = real.into_split();
+    let nonce = match read_message(&mut rr).await.unwrap().unwrap() {
+        Message::AuthChallenge { nonce } => nonce,
+        other => panic!("expected AuthChallenge, got {other:?}"),
+    };
+    let good_mac = {
+        let mut input = Vec::with_capacity(b"bcmr-direct-v1".len() + 32);
+        input.extend_from_slice(b"bcmr-direct-v1");
+        input.extend_from_slice(&nonce);
+        *blake3::keyed_hash(&key, &input).as_bytes()
+    };
+    write_message(&mut rw, &Message::AuthHello { mac: good_mac })
+        .await
+        .unwrap();
+    write_message(
+        &mut rw,
+        &Message::Hello {
+            version: PROTOCOL_VERSION,
+            caps: CAP_AEAD,
+        },
+    )
+    .await
+    .unwrap();
+    match read_message(&mut rr).await.unwrap() {
+        Some(Message::Welcome { .. }) => {}
+        other => panic!("real client was starved by hung squatters, got {other:?}"),
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "serial verify would take 8 * 2s = 16s; got {elapsed:?}"
+    );
+
+    drop(hung);
+    drop(rw);
+    drop(rr);
+    let _ = child.wait().await;
+}
+
+#[tokio::test]
 async fn serve_direct_tcp_refuses_session_without_aead() {
     use bcmr::core::protocol::{
         read_message, write_message, Message, CAP_DIRECT_TCP, PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary

Two LAN-reachable robustness bugs in the direct-TCP path:

1. **Rendezvous verify was serial.** A hung squatter (TCP connect, no AuthHello payload) consumed the full 2s per-connection read budget before the accept loop moved on. 15 such squatters exhaust the 30s outer deadline and starve the legitimate client. Fixed by spawning each verify into its own task and racing via a 1-slot mpsc channel.

2. **Client \`TcpStream::connect\` had no timeout.** Firewall DROP (no RST) rides the kernel SYN retransmit schedule — ~127s default on Linux — before erroring. Now bounded by \`DIRECT_TCP_DIAL_TIMEOUT = 5s\`.

## Test plan

- [x] New regression: \`serve_direct_tcp_hung_squatters_do_not_starve_real_client\` — 8 hung connects + legit client must complete under 2s (serial would be 16s)
- [x] Existing \`serve_direct_tcp_squatter_does_not_starve_real_client\` still passes
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\`
- [x] \`cargo clippy -- -D warnings\`
- [x] 311 tests pass