### PR TITLE
fix: serve-path feature parity (--verify, --preserve, check multi-src)

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -154,20 +154,34 @@ async fn collect_both(
         let rdest = parse_remote_path(&dest_str).ok_or_else(|| {
             BcmrError::InvalidInput(format!("Invalid remote path: {}", dest.display()))
         })?;
-        let rdest_sub = if src_is_dir {
+        let rdest_is_dir = remote_is_dir(&rdest, serve).await.unwrap_or(false);
+        let rdest_sub = if rdest_is_dir {
             rdest.join(&src_name)
         } else {
             rdest
         };
         emit_scanning(&rdest_sub.display());
-        let entries = collect_remote_entries(&rdest_sub, serve)
-            .await
-            .unwrap_or_default();
-        emit_scanning_done(entries.len());
-        entries
+        if src_is_dir {
+            let entries = collect_remote_entries(&rdest_sub, serve)
+                .await
+                .unwrap_or_default();
+            emit_scanning_done(entries.len());
+            entries
+        } else {
+            let entry = match remote_size(&rdest_sub, serve).await {
+                Ok(size) => vec![Entry {
+                    rel_path: src_name.clone(),
+                    size,
+                    is_dir: false,
+                }],
+                Err(_) => Vec::new(),
+            };
+            emit_scanning_done(entry.len());
+            entry
+        }
     } else {
         let dest_is_dir = dest.exists() && dest.is_dir();
-        let resolved_dest = if src_is_dir && dest_is_dir {
+        let resolved_dest = if dest_is_dir {
             dest.join(&src_name)
         } else {
             dest.to_path_buf()
@@ -176,13 +190,8 @@ async fn collect_both(
             collect_local_entries(&resolved_dest, excludes).unwrap_or_default()
         } else if resolved_dest.exists() {
             let size = resolved_dest.metadata()?.len();
-            let fname = resolved_dest
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string();
             vec![Entry {
-                rel_path: fname,
+                rel_path: src_name.clone(),
                 size,
                 is_dir: false,
             }]

--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -90,9 +90,17 @@ pub(super) async fn handle_serve_upload(
                     }
                 }
             }
+            if args.is_preserve() {
+                let target = RemotePath {
+                    user: rdest.user.clone(),
+                    host: rdest.host.clone(),
+                    path: remote_path.clone(),
+                };
+                crate::core::remote::preserve_remote_attrs(src, &target).await?;
+            }
             (runner.inc_callback())(size);
         } else if src.is_dir() && args.is_recursive() {
-            serve_upload_dir(&mut pool, src, rdest, &runner, excludes, args.is_verify()).await?;
+            serve_upload_dir(&mut pool, src, rdest, &runner, excludes, args).await?;
         }
     }
 
@@ -106,7 +114,7 @@ async fn serve_upload_dir(
     remote_base: &RemotePath,
     runner: &ProgressRunner,
     excludes: &[regex::Regex],
-    verify: bool,
+    args: &Commands,
 ) -> Result<()> {
     let dir_name = local_dir.file_name().unwrap_or_default().to_string_lossy();
     let remote_dir = format!("{}/{}", remote_base.path, dir_name);
@@ -129,8 +137,10 @@ async fn serve_upload_dir(
         }
     }
 
-    let verify_inputs: Option<Vec<PathBuf>> =
-        verify.then(|| files_to_put.iter().map(|f| f.local.clone()).collect());
+    let per_file_inputs: Vec<(PathBuf, String)> = files_to_put
+        .iter()
+        .map(|f| (f.local.clone(), f.remote.clone()))
+        .collect();
 
     let file_cb = runner.file_callback();
     let inc_for_chunks = runner.inc_callback();
@@ -143,8 +153,8 @@ async fn serve_upload_dir(
         })
         .await?;
 
-    if let Some(local_paths) = verify_inputs {
-        for (local_path, server_hash) in local_paths.iter().zip(server_hashes.iter()) {
+    if args.is_verify() {
+        for ((local_path, _), server_hash) in per_file_inputs.iter().zip(server_hashes.iter()) {
             let p = local_path.clone();
             let local_hash =
                 tokio::task::spawn_blocking(move || crate::core::checksum::calculate_hash(&p))
@@ -153,6 +163,16 @@ async fn serve_upload_dir(
             if server_hex != local_hash {
                 bail!("hash mismatch for {}", local_path.display());
             }
+        }
+    }
+    if args.is_preserve() {
+        for (local_path, remote_path) in &per_file_inputs {
+            let target = RemotePath {
+                user: remote_base.user.clone(),
+                host: remote_base.host.clone(),
+                path: remote_path.clone(),
+            };
+            crate::core::remote::preserve_remote_attrs(local_path, &target).await?;
         }
     }
     Ok(())
@@ -298,6 +318,42 @@ pub(super) async fn handle_serve_download(
             inc,
         )
         .await?;
+    }
+
+    if args.is_verify() {
+        for item in &items {
+            if item.is_dir {
+                continue;
+            }
+            let p = item.local_path.clone();
+            let local_hash =
+                tokio::task::spawn_blocking(move || crate::core::checksum::calculate_hash(&p))
+                    .await??;
+            let remote_hash = pool.first_mut().hash(&item.remote_path, 0, None).await?;
+            let remote_hex: String = remote_hash.iter().map(|b| format!("{:02x}", b)).collect();
+            if remote_hex != local_hash {
+                pool.close().await?;
+                return runner
+                    .finish_err(format!("hash mismatch for {}", item.local_path.display()));
+            }
+        }
+    }
+    if args.is_preserve() {
+        let (user, host) = match ssh_target.split_once('@') {
+            Some((u, h)) => (Some(u.to_string()), h.to_string()),
+            None => (None, ssh_target.to_string()),
+        };
+        for item in &items {
+            if item.is_dir {
+                continue;
+            }
+            let target = RemotePath {
+                user: user.clone(),
+                host: host.clone(),
+                path: item.remote_path.clone(),
+            };
+            crate::core::remote::apply_remote_attrs_locally(&target, &item.local_path).await?;
+        }
     }
 
     pool.close().await?;

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -5,7 +5,7 @@ mod ssh_cmd;
 mod transfer;
 
 #[allow(unused_imports)]
-pub use attrs::verify_remote_file;
+pub use attrs::{apply_remote_attrs_locally, preserve_remote_attrs, verify_remote_file};
 #[allow(unused_imports)]
 pub use ops::{
     complete_remote_path, remote_file_hash, remote_file_size, remote_list_files, remote_stat,

--- a/src/core/remote/attrs.rs
+++ b/src/core/remote/attrs.rs
@@ -4,10 +4,7 @@ use super::RemotePath;
 use crate::core::error::BcmrError;
 use std::path::Path;
 
-pub(super) async fn preserve_remote_attrs(
-    local_src: &Path,
-    remote: &RemotePath,
-) -> Result<(), BcmrError> {
+pub async fn preserve_remote_attrs(local_src: &Path, remote: &RemotePath) -> Result<(), BcmrError> {
     let meta = local_src.metadata()?;
 
     let mode = {
@@ -111,7 +108,7 @@ fn apply_local_attrs(
     Ok(())
 }
 
-pub(super) async fn apply_remote_attrs_locally(
+pub async fn apply_remote_attrs_locally(
     remote: &RemotePath,
     local_path: &Path,
 ) -> Result<(), BcmrError> {

--- a/src/core/serve_client/ops.rs
+++ b/src/core/serve_client/ops.rs
@@ -46,8 +46,6 @@ impl ServeClient {
         }
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    #[allow(dead_code)]
     pub async fn hash(
         &mut self,
         path: &str,

--- a/tests/e2e_check_tests.rs
+++ b/tests/e2e_check_tests.rs
@@ -1,0 +1,79 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn bcmr_bin() -> PathBuf {
+    let mut path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    path.push("bcmr");
+    if cfg!(windows) {
+        path.set_extension("exe");
+    }
+    path
+}
+
+fn run_bcmr(args: &[&str]) -> (bool, String, String) {
+    let output = Command::new(bcmr_bin())
+        .args(args)
+        .output()
+        .expect("failed to execute bcmr");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).to_string(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+#[test]
+fn e2e_check_multi_source_into_dir_does_not_false_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_a = dir.path().join("a.txt");
+    let src_b = dir.path().join("b.txt");
+    let dst = dir.path().join("dst");
+    fs::create_dir(&dst).unwrap();
+    fs::write(&src_a, b"alpha").unwrap();
+    fs::write(&src_b, b"beta").unwrap();
+    fs::write(dst.join("a.txt"), b"alpha").unwrap();
+    fs::write(dst.join("b.txt"), b"beta").unwrap();
+    fs::write(dst.join("c.txt"), b"unrelated").unwrap();
+
+    let (ok, stdout, _stderr) = run_bcmr(&[
+        "check",
+        src_a.to_str().unwrap(),
+        src_b.to_str().unwrap(),
+        dst.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(ok);
+    assert!(stdout.contains("\"in_sync\":true"), "got: {stdout}");
+    assert!(!stdout.contains("c.txt"), "sibling leaked: {stdout}");
+}
+
+#[test]
+fn e2e_check_multi_source_detects_real_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_a = dir.path().join("a.txt");
+    let src_b = dir.path().join("b.txt");
+    let dst = dir.path().join("dst");
+    fs::create_dir(&dst).unwrap();
+    fs::write(&src_a, b"alpha").unwrap();
+    fs::write(&src_b, b"beta").unwrap();
+    fs::write(dst.join("a.txt"), b"alpha-MODIFIED").unwrap();
+
+    let (_, stdout, _stderr) = run_bcmr(&[
+        "check",
+        src_a.to_str().unwrap(),
+        src_b.to_str().unwrap(),
+        dst.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(stdout.contains("\"in_sync\":false"));
+    assert!(stdout.contains("\"modified\":[{\"path\":\"a.txt\""));
+    assert!(stdout.contains("\"added\":[{\"path\":\"b.txt\""));
+    assert!(!stdout.contains("c.txt"));
+}


### PR DESCRIPTION
## Summary

Three silent semantic regressions on the serve fast path vs legacy SSH path — codex review spotted them as **HIGH**. All are feature-flag regressions: user passed \`--verify\` / \`--preserve\` / \`bcmr check a.txt b.txt dest/\` and the flag was silently a no-op on fast path while working on legacy.

1. **\`bcmr check a.txt b.txt dest/\`** falsely reported every sibling in \`dest/\` as \`missing\`. \`collect_both\` was comparing a single src file vs the entire dest dir listing. Now resolves dest to \`dest/<src_name>\` (local) or stats remote dest (remote) — matches the copy path.
2. **\`--verify\` on serve download** silently dropped. The pipelined reader discarded \`Message::Ok { hash }\`, striped return was \`let _\`-ed. Added post-download verify loop: local BLAKE3 via \`spawn_blocking\` + remote hash via \`ServeClient::hash()\` RPC. Required un-gating \`ServeClient::hash\` from test-support to pub.
3. **\`--preserve\` on serve path** silently dropped. Legacy \`transfer.rs\` calls \`preserve_remote_attrs\` / \`apply_remote_attrs_locally\` per file; \`remote_copy/serve.rs\` never did. Both functions widened from \`pub(super)\` to \`pub\` and re-exported; serve upload/download now apply them at the same per-file granularity as legacy.

## Test plan

- [x] New \`tests/e2e_check_tests.rs\` — multi-source-into-dir must not false-miss siblings; must correctly detect real mismatch.
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\`
- [x] \`cargo clippy -- -D warnings\`
- [x] 313 tests pass