### PR TITLE
fix: serve recursive --exclude + check mtime comparison

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 struct Entry {
     rel_path: String,
     size: u64,
+    mtime: i64,
     is_dir: bool,
 }
 
@@ -136,16 +137,18 @@ async fn collect_both(
             vec![Entry {
                 rel_path: src_name.clone(),
                 size,
+                mtime: 0,
                 is_dir: false,
             }]
         }
     } else if src_is_dir {
         collect_local_entries(src, excludes)?
     } else {
-        let size = src.metadata()?.len();
+        let meta = src.metadata()?;
         vec![Entry {
             rel_path: src_name.clone(),
-            size,
+            size: meta.len(),
+            mtime: mtime_secs(&meta),
             is_dir: false,
         }]
     };
@@ -172,6 +175,7 @@ async fn collect_both(
                 Ok(size) => vec![Entry {
                     rel_path: src_name.clone(),
                     size,
+                    mtime: 0,
                     is_dir: false,
                 }],
                 Err(_) => Vec::new(),
@@ -189,10 +193,11 @@ async fn collect_both(
         if resolved_dest.exists() && resolved_dest.is_dir() {
             collect_local_entries(&resolved_dest, excludes).unwrap_or_default()
         } else if resolved_dest.exists() {
-            let size = resolved_dest.metadata()?.len();
+            let meta = resolved_dest.metadata()?;
             vec![Entry {
                 rel_path: src_name.clone(),
-                size,
+                size: meta.len(),
+                mtime: mtime_secs(&meta),
                 is_dir: false,
             }]
         } else {
@@ -236,6 +241,7 @@ async fn collect_remote_entries(
                     .map(|e| Entry {
                         rel_path: e.path,
                         size: e.size,
+                        mtime: 0,
                         is_dir: e.is_dir,
                     })
                     .collect());
@@ -251,6 +257,7 @@ async fn collect_remote_entries(
         .map(|(rel_path, size, is_dir)| Entry {
             rel_path,
             size,
+            mtime: 0,
             is_dir,
         })
         .collect())
@@ -263,9 +270,11 @@ fn collect_local_entries(root: &Path, excludes: &[regex::Regex]) -> Result<Vec<E
         let path = entry.path();
         let relative = path.strip_prefix(root)?;
         let meta = entry.metadata()?;
+        let mt = if meta.is_dir() { 0 } else { mtime_secs(&meta) };
         entries.push(Entry {
             rel_path: relative.to_string_lossy().to_string(),
             size: if meta.is_dir() { 0 } else { meta.len() },
+            mtime: mt,
             is_dir: meta.is_dir(),
         });
     }
@@ -295,6 +304,14 @@ fn emit_scanning_done(count: usize) {
     eprintln!(" {} entries", count);
 }
 
+fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 fn diff_entries(src: Vec<Entry>, dst: Vec<Entry>) -> (Vec<FileDiff>, Vec<FileDiff>, Vec<FileDiff>) {
     let dst_map: HashMap<&str, &Entry> = dst.iter().map(|e| (e.rel_path.as_str(), e)).collect();
     let src_map: HashMap<&str, &Entry> = src.iter().map(|e| (e.rel_path.as_str(), e)).collect();
@@ -314,7 +331,11 @@ fn diff_entries(src: Vec<Entry>, dst: Vec<Entry>) -> (Vec<FileDiff>, Vec<FileDif
                     is_dir: s.is_dir,
                 });
             }
-            Some(d) if !s.is_dir && s.size != d.size => {
+            Some(d)
+                if !s.is_dir
+                    && (s.size != d.size
+                        || (s.mtime != 0 && d.mtime != 0 && s.mtime != d.mtime)) =>
+            {
                 modified.push(FileDiff {
                     path: PathBuf::from(&s.rel_path),
                     size: None,

--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -226,6 +226,12 @@ pub(super) async fn handle_serve_download(
                     is_dir: true,
                 });
                 for entry in &entries {
+                    if crate::core::traversal::is_excluded(
+                        std::path::Path::new(&entry.path),
+                        excludes,
+                    ) {
+                        continue;
+                    }
                     let local = local_base.join(&entry.path);
                     let remote = format!("{}/{}", rp.path, entry.path);
                     if entry.is_dir {

--- a/tests/e2e_check_tests.rs
+++ b/tests/e2e_check_tests.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::{Duration, SystemTime};
 
 fn bcmr_bin() -> PathBuf {
     let mut path = std::env::current_exe()
@@ -76,4 +77,31 @@ fn e2e_check_multi_source_detects_real_mismatch() {
     assert!(stdout.contains("\"modified\":[{\"path\":\"a.txt\""));
     assert!(stdout.contains("\"added\":[{\"path\":\"b.txt\""));
     assert!(!stdout.contains("c.txt"));
+}
+
+#[test]
+fn e2e_check_same_size_different_mtime_is_modified() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("x.bin");
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+    let dst = dst_dir.join("x.bin");
+    fs::write(&src, b"1234567890").unwrap();
+    fs::write(&dst, b"1234567890").unwrap();
+
+    let old = SystemTime::now() - Duration::from_secs(3600);
+    let ft = filetime::FileTime::from_system_time(old);
+    filetime::set_file_mtime(&dst, ft).unwrap();
+
+    let (_, stdout, _stderr) = run_bcmr(&[
+        "check",
+        src.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(stdout.contains("\"in_sync\":false"), "got: {stdout}");
+    assert!(
+        stdout.contains("\"modified\":[{\"path\":\"x.bin\""),
+        "got: {stdout}"
+    );
 }


### PR DESCRIPTION
## Summary

Two MEDIUM consistency bugs from codex round 3:

1. **\`serve\` recursive download ignored \`--exclude\` on list() children.** Legacy \`download_directory\` filters entries post-list; serve path didn't. Same filter applied now.

2. **\`check\` compared size only; docs say 'size and modification time'.** Added \`mtime\` to \`Entry\`, plumbed through local entry paths, condition ORed with 'both-known && differs'. Remote bulk listings carry \`mtime: 0\` because list/find RPCs don't carry mtime — they fall back to size-only silently.

## Test plan

- [x] New \`e2e_check_same_size_different_mtime_is_modified\` regression
- [x] Existing multi-source / real-mismatch tests still pass
- [x] 314 tests pass
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\`
- [x] \`cargo clippy -- -D warnings\`