### PR TITLE
fix: serve bypass for --resume/--strict/--append + --sync on big downloads

### DIFF
--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -285,7 +285,12 @@ pub async fn handle_remote_copy(
     let serve_parallel = parallel.max(1);
 
     let ssh_target = check_target.ssh_target();
-    let serve_result = if let Some(ref rdest) = remote_dest {
+    let needs_resume_semantics = args.is_resume() || args.is_strict() || args.is_append();
+    let serve_result = if needs_resume_semantics {
+        Err(anyhow::anyhow!(
+            "serve: --resume/--strict/--append not implemented, fallback to legacy"
+        ))
+    } else if let Some(ref rdest) = remote_dest {
         handle_serve_upload(args, sources, rdest, &ssh_target, excludes, serve_parallel).await
     } else {
         handle_serve_download(args, sources, dest, &ssh_target, excludes, serve_parallel).await
@@ -296,7 +301,8 @@ pub async fn handle_remote_copy(
         Err(e) => {
             let msg = e.to_string();
             let is_dry_run_redirect = msg.contains("dry-run fallback");
-            if !is_dry_run_redirect && CONFIG.transfer.fallback_warning {
+            let is_resume_redirect = msg.contains("not implemented, fallback to legacy");
+            if !is_dry_run_redirect && !is_resume_redirect && CONFIG.transfer.fallback_warning {
                 eprintln!(
                     "\nbcmr: serve fast path unavailable ({msg}).\n\
                      bcmr: falling back to legacy SSH (per-file scp \

--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -305,6 +305,10 @@ pub(super) async fn handle_serve_download(
         let _ = pool
             .striped_get_file(remote_path, local_path, *size)
             .await?;
+        if args.is_sync() {
+            let f = tokio::fs::File::open(local_path).await?;
+            crate::core::io::durable_sync_async(&f).await?;
+        }
         (runner.inc_callback())(*size);
     }
 


### PR DESCRIPTION
## Summary

Two more serve-vs-legacy semantic drifts (self-audit after codex's round).

1. **\`--resume\`/\`--strict\`/\`--append\` silently dropped on serve path.** serve never mentions them; \`Put\` is create-or-truncate, \`Get\` is full-stream. Worst case: \`--append\` onto a partially-written remote file **truncates** — opposite of append semantics. Legacy's \`check_resume_state\` handles all three. Fix: one-line dispatcher gate skips serve when any resume flag is set and falls through to legacy. No new protocol work.

2. **\`--sync\` dropped on striped (>= 64 MiB) downloads.** \`sync_after_each\` was passed to the small-file pipelined path; big files went through \`striped_get_file\` with no sync. Added \`durable_sync_async\` after each striped download when \`args.is_sync()\`.

Fix 1 intentionally doesn't implement serve-native resume — that needs protocol work (Put-with-offset, pre-stat). Goal is closing silent-drop, not expanding serve features.

## Test plan

- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\`
- [x] \`cargo clippy -- -D warnings\`
- [x] 314 tests pass