### PR TITLE
chore: SECURITY, CONTRIBUTING, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      rust-minor:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+## Build & test
+
+```
+cargo build
+cargo build --features test-support --tests
+cargo test --features test-support
+```
+
+`test-support` gates loopback spawners used only by integration tests and benches (`ServeClient::connect_local`, `connect_direct_local`, etc.). Without the feature these symbols don't compile — that's intentional, they have no production use.
+
+## Lint & format
+
+CI runs both:
+
+```
+cargo clippy -- -D warnings
+cargo clippy --all-targets --features test-support -- -D warnings
+cargo fmt --check
+```
+
+The `--all-targets` run also lints test and bench code. Both must be green.
+
+## Comments
+
+Add comments only when a competent reader would form a wrong mental model without them. Delete otherwise. This is strict — the codebase has been swept multiple times. Common anti-patterns:
+
+- `//` describing what the next line already says
+- File-level `//!` that restates the filename
+- `///` above self-named items (`pub const AUTH_HELLO_TAG`, `pub fn connect`)
+- "mirrors X on the server" pointers — grep suffices
+- Performance numbers that rot
+
+High-value exceptions: cryptographic invariants, magic errno cross-platform values, hand-rolled wire byte layouts, ordering constraints the type system can't express.
+
+## PR flow
+
+1. Branch from `main`
+2. Push and open PR via `gh pr create`
+3. Wait for both OS runners (ubuntu + windows) to go green
+4. Squash-merge with the PR auto-delete flag
+
+## Running benches and fuzz targets
+
+Benches use the `test-support` feature via `cargo run --example` or `cargo bench`. The `fuzz/` directory requires nightly + `cargo-fuzz`; see `fuzz/README.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest tagged release receives security fixes. Older releases are not backported.
+
+## Reporting a vulnerability
+
+**Do not file public issues for security bugs.** Use GitHub's private security advisory form:
+
+<https://github.com/Bengerthelorf/bcmr/security/advisories/new>
+
+If that's unavailable, email the repository owner (see the `authors` field in `Cargo.toml`).
+
+## Scope
+
+Particularly interested in reports touching:
+
+- The direct-TCP data plane (AES-256-GCM via `ring`): nonce misuse, key reuse, framing desync
+- Rendezvous authentication (`AuthChallenge` / `AuthHello`, blake3 keyed MAC)
+- Path traversal in `bcmr serve` (jail escape under `--root`)
+- Session file format (`src/core/session.rs`): tampering that leads to data corruption on resume
+- CAS (`src/core/cas.rs`): multi-user isolation, symlink / TOCTOU
+
+Out of scope: denial-of-service that requires physical/network access to the user's own machine (this is a CLI file-copy tool, not a network service).
+
+## Response
+
+Best-effort. This is an individual project; there is no SLA. A typical acknowledgement within a week, fix within two weeks for confirmed high-severity issues.


### PR DESCRIPTION
## Summary

GitHub community health 42% → adds the three files that matter for a crypto-touching file-copy tool:

- **\`SECURITY.md\`** — private-advisory channel, scoped interest in the direct-TCP AEAD data plane, rendezvous auth, serve jail, CAS, session format.
- **\`CONTRIBUTING.md\`** — documents the build/lint/test flow actually used (feature=test-support, --all-targets clippy, strict comment policy, PR-before-merge).
- **\`.github/dependabot.yml\`** — weekly cargo + github-actions, minor/patch grouped. \`ring\` / \`blake3\` / \`tokio\` need prompt upstream tracking.

Skipped \`CODE_OF_CONDUCT.md\` / issue & PR templates — low value for an individual project, template-y overhead.

Also removes the tracked-but-unwanted \`.github/.DS_Store\` (was ignored by gitignore but physically present).

## Test plan

- [x] CI still green (no code changes)
- [x] Files render sanely on github.com