### PR TITLE
feat: ListEntry carries mtime; check uses it on remote

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -133,11 +133,11 @@ async fn collect_both(
             emit_scanning_done(entries.len());
             entries
         } else {
-            let size = remote_size(rp, serve).await?;
+            let (size, mtime, _) = remote_stat_full(rp, serve).await?;
             vec![Entry {
                 rel_path: src_name.clone(),
                 size,
-                mtime: 0,
+                mtime,
                 is_dir: false,
             }]
         }
@@ -171,11 +171,11 @@ async fn collect_both(
             emit_scanning_done(entries.len());
             entries
         } else {
-            let entry = match remote_size(&rdest_sub, serve).await {
-                Ok(size) => vec![Entry {
+            let entry = match remote_stat_full(&rdest_sub, serve).await {
+                Ok((size, mtime, _)) => vec![Entry {
                     rel_path: src_name.clone(),
                     size,
-                    mtime: 0,
+                    mtime,
                     is_dir: false,
                 }],
                 Err(_) => Vec::new(),
@@ -220,13 +220,16 @@ async fn remote_is_dir(
     Ok(info.is_dir)
 }
 
-async fn remote_size(rp: &RemotePath, serve: &mut Option<ServeClient>) -> Result<u64, BcmrError> {
+async fn remote_stat_full(
+    rp: &RemotePath,
+    serve: &mut Option<ServeClient>,
+) -> Result<(u64, i64, bool), BcmrError> {
     if let Some(ref mut client) = serve {
-        let (size, _, _) = client.stat(&rp.path).await?;
-        return Ok(size);
+        let (size, mtime, is_dir) = client.stat(&rp.path).await?;
+        return Ok((size, mtime as i64, is_dir));
     }
     let info = remote::remote_stat(rp).await?;
-    Ok(info.size)
+    Ok((info.size, 0, info.is_dir))
 }
 
 async fn collect_remote_entries(
@@ -241,7 +244,7 @@ async fn collect_remote_entries(
                     .map(|e| Entry {
                         rel_path: e.path,
                         size: e.size,
-                        mtime: 0,
+                        mtime: e.mtime,
                         is_dir: e.is_dir,
                     })
                     .collect());

--- a/src/commands/serve/handlers.rs
+++ b/src/commands/serve/handlers.rs
@@ -40,9 +40,16 @@ pub(super) async fn handle_list(path: &str) -> Result<Message> {
                 .to_string_lossy()
                 .into_owned();
             let meta = entry.metadata()?;
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
             out.push(ListEntry {
                 path: rel,
                 size: meta.len(),
+                mtime,
                 is_dir: meta.is_dir(),
             });
         }

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -92,6 +92,7 @@ impl CompressionAlgo {
 pub struct ListEntry {
     pub path: String,
     pub size: u64,
+    pub mtime: i64,
     pub is_dir: bool,
 }
 
@@ -246,6 +247,7 @@ fn write_opt_u64(buf: &mut Vec<u8>, opt: &Option<u64>) {
 fn write_list_entry(buf: &mut Vec<u8>, entry: &ListEntry) {
     write_string(buf, &entry.path);
     write_u64_le(buf, entry.size);
+    write_i64_le(buf, entry.mtime);
     write_u8(buf, entry.is_dir as u8);
 }
 
@@ -491,8 +493,14 @@ impl<'a> Cursor<'a> {
     fn read_list_entry(&mut self) -> Option<ListEntry> {
         let path = self.read_string()?;
         let size = self.read_u64_le()?;
+        let mtime = self.read_i64_le()?;
         let is_dir = self.read_u8()? != 0;
-        Some(ListEntry { path, size, is_dir })
+        Some(ListEntry {
+            path,
+            size,
+            mtime,
+            is_dir,
+        })
     }
 }
 

--- a/tests/proptest_codec.rs
+++ b/tests/proptest_codec.rs
@@ -10,11 +10,14 @@ fn arb_hash() -> impl Strategy<Value = [u8; 32]> {
 }
 
 fn arb_list_entry() -> impl Strategy<Value = ListEntry> {
-    (arb_string(), any::<u64>(), any::<bool>()).prop_map(|(path, size, is_dir)| ListEntry {
-        path,
-        size,
-        is_dir,
-    })
+    (arb_string(), any::<u64>(), any::<i64>(), any::<bool>()).prop_map(
+        |(path, size, mtime, is_dir)| ListEntry {
+            path,
+            size,
+            mtime,
+            is_dir,
+        },
+    )
 }
 
 fn arb_message() -> impl Strategy<Value = Message> {

--- a/tests/serve_protocol_tests.rs
+++ b/tests/serve_protocol_tests.rs
@@ -171,16 +171,19 @@ fn test_list_response_multiple_entries_roundtrip() {
             ListEntry {
                 path: "/home/user/a.txt".to_string(),
                 size: 1024,
+                mtime: 1700000000,
                 is_dir: false,
             },
             ListEntry {
                 path: "/home/user/subdir".to_string(),
                 size: 0,
+                mtime: 0,
                 is_dir: true,
             },
             ListEntry {
                 path: "/home/user/b.bin".to_string(),
                 size: 999_999,
+                mtime: -1,
                 is_dir: false,
             },
         ],


### PR DESCRIPTION
## Summary

Closes the documented gap in \`check\` where remote \`ListEntry\` wire messages carried no mtime, so remote-vs-local same-size-different-mtime files were falsely reported as in-sync.

- \`protocol.rs\`: \`ListEntry\` gains an \`i64 mtime\` (written between size and is_dir via write_i64_le).
- \`serve/handlers.rs::handle_list\`: populates mtime from \`Metadata::modified()\` (seconds since epoch, 0 on error).
- \`check.rs\`: consumes \`ListEntry.mtime\` directly; \`remote_stat_full\` helper surfaces mtime for single-file remote stat paths too.

No backward-compat shim — both ends of a bcmr conversation ship together, so the wire bump is safe.

## Test plan

- [x] Updated \`serve_protocol_tests\` roundtrip asserts the new field
- [x] \`proptest_codec\` arb_list_entry now generates arbitrary \`i64\` mtime
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\`
- [x] \`cargo clippy -- -D warnings\`
- [x] 314 tests pass