### PR TITLE
feat: serve upload resume via Put{offset}; drop dispatcher bypass for files

### DIFF
--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -285,12 +285,7 @@ pub async fn handle_remote_copy(
     let serve_parallel = parallel.max(1);
 
     let ssh_target = check_target.ssh_target();
-    let needs_resume_semantics = args.is_resume() || args.is_strict() || args.is_append();
-    let serve_result = if needs_resume_semantics {
-        Err(anyhow::anyhow!(
-            "serve: --resume/--strict/--append not implemented, fallback to legacy"
-        ))
-    } else if let Some(ref rdest) = remote_dest {
+    let serve_result = if let Some(ref rdest) = remote_dest {
         handle_serve_upload(args, sources, rdest, &ssh_target, excludes, serve_parallel).await
     } else {
         handle_serve_download(args, sources, dest, &ssh_target, excludes, serve_parallel).await
@@ -301,7 +296,8 @@ pub async fn handle_remote_copy(
         Err(e) => {
             let msg = e.to_string();
             let is_dry_run_redirect = msg.contains("dry-run fallback");
-            let is_resume_redirect = msg.contains("not implemented, fallback to legacy");
+            let is_resume_redirect = msg.contains("not yet supported, fallback to legacy")
+                || msg.contains("not supported, fallback to legacy");
             if !is_dry_run_redirect && !is_resume_redirect && CONFIG.transfer.fallback_warning {
                 eprintln!(
                     "\nbcmr: serve fast path unavailable ({msg}).\n\

--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -1,10 +1,87 @@
-use super::{is_plain_mode, STRIPING_MIN_FILE_SIZE};
+use super::{is_plain_mode, transfer_options_from_cli, STRIPING_MIN_FILE_SIZE};
 use crate::cli::Commands;
-use crate::core::remote::{parse_remote_path, RemotePath};
+use crate::core::remote::{check_resume_state, parse_remote_path, RemotePath, ResumeDecision};
 use crate::core::serve_client::{FileTransfer, ServeClientPool};
 use crate::ui::runner::ProgressRunner;
 use anyhow::{bail, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+enum UploadDecision {
+    Skip,
+    Overwrite,
+    Append(u64),
+}
+
+async fn upload_resume_offset(
+    pool: &mut ServeClientPool,
+    args: &Commands,
+    local_src: &Path,
+    remote_path: &str,
+    local_size: u64,
+) -> Result<Option<UploadDecision>> {
+    let opts = transfer_options_from_cli(args);
+    if !(opts.resume || opts.append || opts.strict) {
+        return Ok(None);
+    }
+    let existing_size = match pool.first_mut().stat(remote_path).await {
+        Ok((size, _mtime, is_dir)) => {
+            if is_dir {
+                bail!("remote path {remote_path} is a directory");
+            }
+            Some(size)
+        }
+        Err(_) => None,
+    };
+    let local_clone = local_src.to_path_buf();
+    let remote_str = remote_path.to_string();
+    let decision = check_resume_state(
+        &opts,
+        existing_size,
+        local_size,
+        async move || {
+            let bytes = pool_hash(pool, &remote_str, None).await?;
+            Ok(hex_of(&bytes))
+        },
+        async move || {
+            let p = local_clone.clone();
+            let h = tokio::task::spawn_blocking(move || crate::core::checksum::calculate_hash(&p))
+                .await??;
+            Ok(h)
+        },
+        async move |limit| {
+            let p = local_src.to_path_buf();
+            let h = tokio::task::spawn_blocking(move || {
+                crate::core::checksum::calculate_partial_hash(&p, limit)
+            })
+            .await??;
+            Ok(h)
+        },
+    )
+    .await?;
+    Ok(Some(to_upload_decision(decision)))
+}
+
+async fn pool_hash(
+    pool: &mut ServeClientPool,
+    remote: &str,
+    limit: Option<u64>,
+) -> Result<[u8; 32], crate::core::error::BcmrError> {
+    pool.first_mut().hash(remote, 0, limit).await
+}
+
+fn hex_of(b: &[u8; 32]) -> String {
+    b.iter().map(|x| format!("{:02x}", x)).collect()
+}
+
+fn to_upload_decision(d: ResumeDecision) -> UploadDecision {
+    if d.skip_entirely {
+        UploadDecision::Skip
+    } else if d.use_append_mode && d.skip_bytes > 0 {
+        UploadDecision::Append(d.skip_bytes)
+    } else {
+        UploadDecision::Overwrite
+    }
+}
 
 pub(super) async fn handle_serve_upload(
     args: &Commands,
@@ -67,13 +144,41 @@ pub(super) async fn handle_serve_upload(
             let size = src.metadata()?.len();
             (runner.file_callback())(&src.file_name().unwrap_or_default().to_string_lossy(), size);
 
+            let resume_offset =
+                upload_resume_offset(&mut pool, args, src, &remote_path, size).await?;
+            if let Some(UploadDecision::Skip) = resume_offset {
+                (runner.inc_callback())(size);
+                continue;
+            }
+            let offset = match resume_offset {
+                Some(UploadDecision::Append(o)) => o,
+                _ => 0,
+            };
+
             let use_stripe = args.use_direct_tcp()
                 && pool.len() > 1
                 && size >= STRIPING_MIN_FILE_SIZE
-                && !args.is_verify();
+                && !args.is_verify()
+                && offset == 0;
 
             if use_stripe {
                 let _ = pool.striped_put_file(src, &remote_path).await?;
+            } else if offset > 0 {
+                pool.first_mut().put_at(&remote_path, src, offset).await?;
+                if args.is_verify() {
+                    let p = src.to_path_buf();
+                    let local_hash = tokio::task::spawn_blocking(move || {
+                        crate::core::checksum::calculate_hash(&p)
+                    })
+                    .await??;
+                    let remote_hash = pool.first_mut().hash(&remote_path, 0, None).await?;
+                    let remote_hex: String =
+                        remote_hash.iter().map(|b| format!("{:02x}", b)).collect();
+                    if remote_hex != local_hash {
+                        pool.close().await?;
+                        return runner.finish_err(format!("hash mismatch for {}", src.display()));
+                    }
+                }
             } else {
                 let server_hash = pool.first_mut().put(&remote_path, src).await?;
                 if args.is_verify() {
@@ -100,6 +205,12 @@ pub(super) async fn handle_serve_upload(
             }
             (runner.inc_callback())(size);
         } else if src.is_dir() && args.is_recursive() {
+            if args.is_resume() || args.is_strict() || args.is_append() {
+                pool.close().await?;
+                return Err(anyhow::anyhow!(
+                    "serve: recursive --resume/--strict/--append not supported, fallback to legacy"
+                ));
+            }
             serve_upload_dir(&mut pool, src, rdest, &runner, excludes, args).await?;
         }
     }
@@ -192,6 +303,13 @@ pub(super) async fn handle_serve_download(
         ServeClientPool::connect_with_caps(ssh_target, args.protocol_caps(), parallel).await
     }
     .map_err(|e| anyhow::anyhow!("serve unavailable: {}", e))?;
+
+    if args.is_resume() || args.is_strict() || args.is_append() {
+        pool.close().await?;
+        return Err(anyhow::anyhow!(
+            "serve: download --resume/--strict/--append not yet supported, fallback to legacy"
+        ));
+    }
 
     if args.is_dry_run() {
         pool.close().await?;

--- a/src/commands/serve/handlers.rs
+++ b/src/commands/serve/handlers.rs
@@ -296,6 +296,7 @@ fn write_all_fd(fd: i32, mut buf: &[u8]) -> std::io::Result<()> {
 pub(super) async fn handle_put<W, R>(
     path: &str,
     declared_size: u64,
+    offset: u64,
     sync: bool,
     out: &mut W,
     reader: &mut R,
@@ -305,37 +306,63 @@ where
     W: tokio::io::AsyncWrite + Unpin,
     R: tokio::io::AsyncRead + Unpin,
 {
+    use tokio::io::AsyncSeekExt;
+
+    if offset > declared_size {
+        bail!(
+            "put: offset {} past declared size {}",
+            offset,
+            declared_size
+        );
+    }
     ensure_parent_dir(path).await?;
 
-    let mut file = fs::File::create(path).await?;
-    let mut hasher = blake3::Hasher::new();
-    let mut written: u64 = 0;
+    let mut file = if offset == 0 {
+        fs::File::create(path).await?
+    } else {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .await?;
+        f.seek(std::io::SeekFrom::Start(offset)).await?;
+        f
+    };
+    let mut hasher = if offset == 0 {
+        Some(blake3::Hasher::new())
+    } else {
+        None
+    };
+    let mut written: u64 = offset;
 
     let first = framing.read_message(reader).await?;
     let mut dedup_state: Option<DedupState> = None;
     let mut next: Option<Message> = first;
 
-    if let Some(Message::HaveBlocks { hashes, .. }) = next {
-        if let Some(cap) = cas::cap_bytes() {
-            let _ = tokio::task::spawn_blocking(move || cas::evict_to_cap(cap)).await;
-        }
-
-        let mut bits = vec![0u8; hashes.len().div_ceil(8)];
-        for (i, h) in hashes.iter().enumerate() {
-            if !cas::has(h) {
-                bits[i / 8] |= 1 << (i % 8);
+    if offset == 0 {
+        if let Some(Message::HaveBlocks { hashes, .. }) = next {
+            if let Some(cap) = cas::cap_bytes() {
+                let _ = tokio::task::spawn_blocking(move || cas::evict_to_cap(cap)).await;
             }
+
+            let mut bits = vec![0u8; hashes.len().div_ceil(8)];
+            for (i, h) in hashes.iter().enumerate() {
+                if !cas::has(h) {
+                    bits[i / 8] |= 1 << (i % 8);
+                }
+            }
+            framing
+                .write_message(out, &Message::MissingBlocks { bits: bits.clone() })
+                .await?;
+            out.flush().await?;
+            dedup_state = Some(DedupState {
+                hashes,
+                bits,
+                cursor: 0,
+            });
+            next = None;
         }
-        framing
-            .write_message(out, &Message::MissingBlocks { bits: bits.clone() })
-            .await?;
-        out.flush().await?;
-        dedup_state = Some(DedupState {
-            hashes,
-            bits,
-            cursor: 0,
-        });
-        next = None;
     }
 
     let mut msg = next;
@@ -352,7 +379,7 @@ where
                 consume_block(
                     &payload,
                     &mut file,
-                    &mut hasher,
+                    hasher.as_mut(),
                     dedup_state.as_mut(),
                     &mut written,
                     declared_size,
@@ -368,7 +395,7 @@ where
                 consume_block(
                     &decoded,
                     &mut file,
-                    &mut hasher,
+                    hasher.as_mut(),
                     dedup_state.as_mut(),
                     &mut written,
                     declared_size,
@@ -381,8 +408,14 @@ where
     }
 
     if let Some(state) = dedup_state.as_mut() {
-        flush_remaining_cas_blocks(state, &mut file, &mut hasher, &mut written, declared_size)
-            .await?;
+        flush_remaining_cas_blocks(
+            state,
+            &mut file,
+            hasher.as_mut(),
+            &mut written,
+            declared_size,
+        )
+        .await?;
     }
     if written != declared_size {
         bail!(
@@ -398,8 +431,8 @@ where
     }
     drop(file);
 
-    let hash = hasher.finalize().to_hex().to_string();
-    Ok(Message::Ok { hash: Some(hash) })
+    let hash = hasher.map(|h| h.finalize().to_hex().to_string());
+    Ok(Message::Ok { hash })
 }
 
 struct DedupState {
@@ -417,7 +450,7 @@ impl DedupState {
 async fn consume_block(
     block: &[u8],
     file: &mut tokio::fs::File,
-    hasher: &mut blake3::Hasher,
+    mut hasher: Option<&mut blake3::Hasher>,
     dedup: Option<&mut DedupState>,
     written: &mut u64,
     declared_size: u64,
@@ -426,7 +459,9 @@ async fn consume_block(
         while state.cursor < state.hashes.len() && !state.is_missing(state.cursor) {
             let cached = cas::read(&state.hashes[state.cursor])?;
             enforce_write_bound(*written, cached.len(), declared_size)?;
-            hasher.update(&cached);
+            if let Some(h) = hasher.as_mut() {
+                h.update(&cached);
+            }
             file.write_all(&cached).await?;
             *written += cached.len() as u64;
             state.cursor += 1;
@@ -439,7 +474,9 @@ async fn consume_block(
         }
     }
     enforce_write_bound(*written, block.len(), declared_size)?;
-    hasher.update(block);
+    if let Some(h) = hasher.as_mut() {
+        h.update(block);
+    }
     file.write_all(block).await?;
     *written += block.len() as u64;
     Ok(())
@@ -448,7 +485,7 @@ async fn consume_block(
 async fn flush_remaining_cas_blocks(
     state: &mut DedupState,
     file: &mut tokio::fs::File,
-    hasher: &mut blake3::Hasher,
+    mut hasher: Option<&mut blake3::Hasher>,
     written: &mut u64,
     declared_size: u64,
 ) -> Result<()> {
@@ -461,7 +498,9 @@ async fn flush_remaining_cas_blocks(
         }
         let cached = cas::read(&state.hashes[state.cursor])?;
         enforce_write_bound(*written, cached.len(), declared_size)?;
-        hasher.update(&cached);
+        if let Some(h) = hasher.as_mut() {
+            h.update(&cached);
+        }
         file.write_all(&cached).await?;
         *written += cached.len() as u64;
         state.cursor += 1;

--- a/src/commands/serve/session.rs
+++ b/src/commands/serve/session.rs
@@ -172,11 +172,12 @@ where
                 Ok(p) => handle_hash(p.to_str().unwrap_or(&path), offset, limit).await,
                 Err(e) => Err(e),
             },
-            Message::Put { path, size } => match validate_path(&path, root) {
+            Message::Put { path, size, offset } => match validate_path(&path, root) {
                 Ok(p) => {
                     handle_put(
                         p.to_str().unwrap_or(&path),
                         size,
+                        offset,
                         sync,
                         writer,
                         reader,

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -120,6 +120,7 @@ pub enum Message {
     Put {
         path: String,
         size: u64,
+        offset: u64,
     },
     Mkdir {
         path: String,
@@ -283,10 +284,11 @@ pub fn encode_message(msg: &Message) -> Vec<u8> {
             write_string(&mut payload, path);
             write_u64_le(&mut payload, *offset);
         }
-        Message::Put { path, size } => {
+        Message::Put { path, size, offset } => {
             write_u8(&mut payload, TYPE_PUT);
             write_string(&mut payload, path);
             write_u64_le(&mut payload, *size);
+            write_u64_le(&mut payload, *offset);
         }
         Message::Mkdir { path } => {
             write_u8(&mut payload, TYPE_MKDIR);
@@ -539,6 +541,7 @@ pub fn decode_message(data: &[u8]) -> Option<Message> {
         TYPE_PUT => Message::Put {
             path: p.read_string()?,
             size: p.read_u64_le()?,
+            offset: p.read_u64_le()?,
         },
         TYPE_MKDIR => Message::Mkdir {
             path: p.read_string()?,

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -11,6 +11,7 @@ pub use ops::{
     complete_remote_path, remote_file_hash, remote_file_size, remote_list_files, remote_stat,
     remote_total_size, validate_ssh_connection,
 };
+pub use resume::{check_resume_state, ResumeDecision};
 pub use transfer::{
     download_directory, download_file, ensure_remote_tree, upload_directory, upload_file,
 };

--- a/src/core/remote/resume.rs
+++ b/src/core/remote/resume.rs
@@ -1,13 +1,13 @@
 use super::RemoteTransferOptions;
 use crate::core::error::BcmrError;
 
-pub(super) struct ResumeDecision {
-    pub(super) skip_bytes: u64,
-    pub(super) use_append_mode: bool,
-    pub(super) skip_entirely: bool,
+pub struct ResumeDecision {
+    pub skip_bytes: u64,
+    pub use_append_mode: bool,
+    pub skip_entirely: bool,
 }
 
-pub(super) async fn check_resume_state(
+pub async fn check_resume_state(
     opts: &RemoteTransferOptions,
     existing_size: Option<u64>,
     source_size: u64,

--- a/src/core/serve_client.rs
+++ b/src/core/serve_client.rs
@@ -180,7 +180,25 @@ async fn write_file_data_frames<W>(
 where
     W: tokio::io::AsyncWrite + Unpin,
 {
+    write_file_data_frames_from(writer, tx, data, 0, algo, on_chunk).await
+}
+
+async fn write_file_data_frames_from<W>(
+    writer: &mut W,
+    tx: &mut SendHalf,
+    data: &Path,
+    offset: u64,
+    algo: CompressionAlgo,
+    on_chunk: &(impl Fn(u64) + ?Sized),
+) -> Result<(), BcmrError>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::AsyncSeekExt;
     let mut file = File::open(data).await?;
+    if offset > 0 {
+        file.seek(std::io::SeekFrom::Start(offset)).await?;
+    }
     let mut buf = vec![0u8; DEDUP_BLOCK_SIZE];
     loop {
         let n = file.read(&mut buf).await?;

--- a/src/core/serve_client/ops.rs
+++ b/src/core/serve_client/ops.rs
@@ -114,6 +114,7 @@ impl ServeClient {
         self.send(&Message::Put {
             path: path.to_owned(),
             size,
+            offset: 0,
         })
         .await?;
 
@@ -134,6 +135,45 @@ impl ServeClient {
                 "unexpected put response: {other:?}"
             ))),
         }
+    }
+
+    pub async fn put_at(&mut self, path: &str, data: &Path, offset: u64) -> Result<(), BcmrError> {
+        let metadata = tokio::fs::metadata(data).await?;
+        let size = metadata.len();
+        if offset > size {
+            return Err(BcmrError::InvalidInput(format!(
+                "put_at: offset {offset} past local size {size}"
+            )));
+        }
+        self.send(&Message::Put {
+            path: path.to_owned(),
+            size,
+            offset,
+        })
+        .await?;
+        self.put_streaming_from(data, offset).await?;
+        self.send(&Message::Done).await?;
+        match self.recv().await? {
+            Message::Ok { .. } => Ok(()),
+            Message::Error { message } => Err(BcmrError::InvalidInput(message)),
+            other => Err(BcmrError::InvalidInput(format!(
+                "unexpected put_at response: {other:?}"
+            ))),
+        }
+    }
+
+    async fn put_streaming_from(&mut self, data: &Path, offset: u64) -> Result<(), BcmrError> {
+        let algo = self.algo;
+        let w = self
+            .writer
+            .as_mut()
+            .ok_or_else(|| BcmrError::InvalidInput("writer already taken".into()))?;
+        let tx = self
+            .tx
+            .as_mut()
+            .ok_or_else(|| BcmrError::InvalidInput("send framing taken".into()))?;
+        super::super::serve_client::write_file_data_frames_from(w, tx, data, offset, algo, &|_| {})
+            .await
     }
 
     async fn put_streaming(&mut self, data: &Path) -> Result<(), BcmrError> {

--- a/src/core/serve_client/pipelined.rs
+++ b/src/core/serve_client/pipelined.rs
@@ -55,6 +55,7 @@ impl ServeClient {
                         &Message::Put {
                             path: ft.remote,
                             size: ft.size,
+                            offset: 0,
                         },
                     )
                     .await?;

--- a/tests/e2e_serve_basic.rs
+++ b/tests/e2e_serve_basic.rs
@@ -44,6 +44,7 @@ async fn serve_root_jail_rejects_escape() {
         &Message::Put {
             path: outside_target.to_string_lossy().into_owned(),
             size: 5,
+            offset: 0,
         },
     )
     .await
@@ -95,6 +96,7 @@ async fn serve_put_size_bound_rejects_oversized() {
         &Message::Put {
             path: dst.to_string_lossy().into_owned(),
             size: 10,
+            offset: 0,
         },
     )
     .await
@@ -153,6 +155,7 @@ async fn serve_put_size_bound_rejects_short_write() {
         &Message::Put {
             path: dst.to_string_lossy().into_owned(),
             size: 10,
+            offset: 0,
         },
     )
     .await

--- a/tests/e2e_serve_listen.rs
+++ b/tests/e2e_serve_listen.rs
@@ -60,6 +60,7 @@ async fn serve_listen_tcp_handshake_and_put() {
         &Message::Put {
             path: dst.to_string_lossy().into_owned(),
             size: payload.len() as u64,
+            offset: 0,
         },
     )
     .await

--- a/tests/proptest_codec.rs
+++ b/tests/proptest_codec.rs
@@ -33,7 +33,11 @@ fn arb_message() -> impl Strategy<Value = Message> {
             }
         ),
         (arb_string(), any::<u64>()).prop_map(|(path, offset)| Message::Get { path, offset }),
-        (arb_string(), any::<u64>()).prop_map(|(path, size)| Message::Put { path, size }),
+        (arb_string(), any::<u64>(), any::<u64>()).prop_map(|(path, size, offset)| Message::Put {
+            path,
+            size,
+            offset
+        }),
         arb_string().prop_map(|path| Message::Mkdir { path }),
         arb_string().prop_map(|path| Message::Resume { path }),
         Just(Message::Done),

--- a/tests/serve_protocol_tests.rs
+++ b/tests/serve_protocol_tests.rs
@@ -222,6 +222,7 @@ fn test_put_roundtrip() {
     let msg = Message::Put {
         path: "/remote/dest.bin".to_string(),
         size: 4_294_967_295,
+        offset: 123_456,
     };
     assert_eq!(roundtrip(msg.clone()), msg);
 }


### PR DESCRIPTION
## Summary

- Extend `Put { path, size, offset }` wire frame with an offset field; `offset == 0` preserves prior semantics (truncate + BLAKE3 + `Ok { hash: Some }`), `offset > 0` opens without truncate, seeks, skips dedup preflight, returns `Ok { hash: None }`
- New `ServeClient::put_at(path, data, offset)` streams local file from offset; `put()` continues to use offset=0
- Single-file serve upload now handles resume natively via `check_resume_state` (widened to `pub`) + pool-backed hashers; append → `put_at`, overwrite → `put`, skip when fully up-to-date
- Removed the static dispatcher bypass that routed all `--resume/--strict/--append` uploads to legacy; directory upload and all downloads still bail internally so the warning-gated fallback kicks in

## Test plan

- [x] `cargo test` (314 tests pass)
- [x] `cargo clippy --all-targets` clean (default + `--features test-support`)
- [x] proptest codec + serve_protocol + e2e tests updated for new Put field
- [ ] CI: ubuntu + windows runners green