### PR TITLE
fix: check --exclude symmetry + --sync honored on legacy downloads

### DIFF
--- a/docs/guide/remote-copy.md
+++ b/docs/guide/remote-copy.md
@@ -178,7 +178,7 @@ server-side integrity verification.
 
 ::: warning Limitations
 - Cannot copy between two remote hosts directly — use a local intermediary
-- Resume (`-C`) is not yet available for serve-based remote transfers (use legacy mode with `-P 1`)
+- Resume (`-C`) on serve fast path: single-file uploads are supported natively. Recursive directory uploads and downloads with `--resume/--strict/--append` fall back to legacy mode automatically.
 :::
 
 ## Path Detection

--- a/docs/zh-Hant/guide/remote-copy.md
+++ b/docs/zh-Hant/guide/remote-copy.md
@@ -150,7 +150,7 @@ bcmr copy --fast -V user@host:/big.bin ./local.bin
 
 ::: warning 限制
 - 無法直接在兩個遠端主機之間複製 — 請使用本機作為中轉
-- Serve 協定暫不支援斷點續傳（`-C`），需續傳時使用傳統模式（`-P 1`）
+- Serve 快路徑的斷點續傳（`-C`）：單檔案上傳已原生支援；遞迴目錄上傳和所有下載在指定 `--resume/--strict/--append` 時自動回退到傳統模式
 :::
 
 ## 路徑偵測

--- a/docs/zh/guide/remote-copy.md
+++ b/docs/zh/guide/remote-copy.md
@@ -153,7 +153,7 @@ bcmr copy --fast -V user@host:/big.bin ./local.bin
 
 ::: warning 限制
 - 无法直接在两个远程主机之间复制 — 请使用本地作为中转
-- Serve 协议暂不支持断点续传（`-C`），需续传时使用传统模式（`-P 1`）
+- Serve 快路径的断点续传（`-C`）：单文件上传已原生支持；递归目录上传和所有下载在指定 `--resume/--strict/--append` 时自动回退到传统模式
 :::
 
 ## 路径检测

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -269,37 +269,6 @@ async fn collect_remote_entries(
         .collect())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn entry(path: &str) -> Entry {
-        Entry {
-            rel_path: path.into(),
-            size: 0,
-            mtime: 0,
-            is_dir: false,
-        }
-    }
-
-    #[test]
-    fn filter_entries_matches_local_traversal_semantics() {
-        let excludes = vec![regex::Regex::new(r"\.log$").unwrap()];
-        let out = filter_entries(
-            vec![entry("a/b.txt"), entry("a/c.log"), entry("d.LOG")],
-            &excludes,
-        );
-        let paths: Vec<_> = out.iter().map(|e| e.rel_path.as_str()).collect();
-        assert_eq!(paths, vec!["a/b.txt", "d.LOG"]);
-    }
-
-    #[test]
-    fn filter_entries_noop_without_rules() {
-        let out = filter_entries(vec![entry("x"), entry("y")], &[]);
-        assert_eq!(out.len(), 2);
-    }
-}
-
 fn filter_entries(entries: Vec<Entry>, excludes: &[regex::Regex]) -> Vec<Entry> {
     if excludes.is_empty() {
         return entries;
@@ -439,5 +408,36 @@ fn build_result(
         summary,
         error: None,
         error_kind: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str) -> Entry {
+        Entry {
+            rel_path: path.into(),
+            size: 0,
+            mtime: 0,
+            is_dir: false,
+        }
+    }
+
+    #[test]
+    fn filter_entries_matches_local_traversal_semantics() {
+        let excludes = vec![regex::Regex::new(r"\.log$").unwrap()];
+        let out = filter_entries(
+            vec![entry("a/b.txt"), entry("a/c.log"), entry("d.LOG")],
+            &excludes,
+        );
+        let paths: Vec<_> = out.iter().map(|e| e.rel_path.as_str()).collect();
+        assert_eq!(paths, vec!["a/b.txt", "d.LOG"]);
+    }
+
+    #[test]
+    fn filter_entries_noop_without_rules() {
+        let out = filter_entries(vec![entry("x"), entry("y")], &[]);
+        assert_eq!(out.len(), 2);
     }
 }

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -129,7 +129,7 @@ async fn collect_both(
     let src_entries = if let Some(ref rp) = remote_src {
         if src_is_dir {
             emit_scanning(&rp.display());
-            let entries = collect_remote_entries(rp, serve).await?;
+            let entries = filter_entries(collect_remote_entries(rp, serve).await?, excludes);
             emit_scanning_done(entries.len());
             entries
         } else {
@@ -165,9 +165,12 @@ async fn collect_both(
         };
         emit_scanning(&rdest_sub.display());
         if src_is_dir {
-            let entries = collect_remote_entries(&rdest_sub, serve)
-                .await
-                .unwrap_or_default();
+            let entries = filter_entries(
+                collect_remote_entries(&rdest_sub, serve)
+                    .await
+                    .unwrap_or_default(),
+                excludes,
+            );
             emit_scanning_done(entries.len());
             entries
         } else {
@@ -264,6 +267,47 @@ async fn collect_remote_entries(
             is_dir,
         })
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str) -> Entry {
+        Entry {
+            rel_path: path.into(),
+            size: 0,
+            mtime: 0,
+            is_dir: false,
+        }
+    }
+
+    #[test]
+    fn filter_entries_matches_local_traversal_semantics() {
+        let excludes = vec![regex::Regex::new(r"\.log$").unwrap()];
+        let out = filter_entries(
+            vec![entry("a/b.txt"), entry("a/c.log"), entry("d.LOG")],
+            &excludes,
+        );
+        let paths: Vec<_> = out.iter().map(|e| e.rel_path.as_str()).collect();
+        assert_eq!(paths, vec!["a/b.txt", "d.LOG"]);
+    }
+
+    #[test]
+    fn filter_entries_noop_without_rules() {
+        let out = filter_entries(vec![entry("x"), entry("y")], &[]);
+        assert_eq!(out.len(), 2);
+    }
+}
+
+fn filter_entries(entries: Vec<Entry>, excludes: &[regex::Regex]) -> Vec<Entry> {
+    if excludes.is_empty() {
+        return entries;
+    }
+    entries
+        .into_iter()
+        .filter(|e| !excludes.iter().any(|r| r.is_match(&e.rel_path)))
+        .collect()
 }
 
 fn collect_local_entries(root: &Path, excludes: &[regex::Regex]) -> Result<Vec<Entry>, BcmrError> {

--- a/src/commands/copy/file_copy.rs
+++ b/src/commands/copy/file_copy.rs
@@ -119,7 +119,6 @@ fn is_unsupported(e: &std::io::Error) -> bool {
 
 pub(super) struct CopyFileOptions {
     transfer: crate::core::remote::TransferOptions,
-    sync: bool,
     reflink_arg: Option<String>,
     sparse_arg: Option<String>,
     test_mode: TestMode,
@@ -134,8 +133,8 @@ impl CopyFileOptions {
                 resume: cli.is_resume(),
                 strict: cli.is_strict(),
                 append: cli.is_append(),
+                sync: cli.is_sync(),
             },
-            sync: cli.is_sync(),
             reflink_arg: cli.get_reflink_mode(),
             sparse_arg: cli.get_sparse_mode(),
             test_mode,
@@ -183,7 +182,6 @@ where
 {
     let CopyFileOptions {
         transfer,
-        sync,
         ref reflink_arg,
         ref sparse_arg,
         test_mode,
@@ -194,6 +192,7 @@ where
         resume,
         strict,
         append,
+        sync,
     } = transfer;
 
     let file_size = src.metadata()?.len();

--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -22,6 +22,7 @@ pub(super) fn transfer_options_from_cli(cli: &Commands) -> remote::TransferOptio
         resume: cli.is_resume(),
         strict: cli.is_strict(),
         append: cli.is_append(),
+        sync: cli.is_sync(),
     }
 }
 
@@ -299,12 +300,18 @@ pub async fn handle_remote_copy(
             let is_resume_redirect = msg.contains("not yet supported, fallback to legacy")
                 || msg.contains("not supported, fallback to legacy");
             if !is_dry_run_redirect && !is_resume_redirect && CONFIG.transfer.fallback_warning {
+                let sync_caveat = if args.is_sync() && is_upload {
+                    "\n                     bcmr: --sync on legacy uploads is best-effort \
+                     (scp does not guarantee remote fsync)."
+                } else {
+                    ""
+                };
                 eprintln!(
                     "\nbcmr: serve fast path unavailable ({msg}).\n\
                      bcmr: falling back to legacy SSH (per-file scp \
                      workers) — slower by ~5-10× on many-file batches.\n\
                      bcmr: set `transfer.fallback_warning = false` in \
-                     ~/.config/bcmr/config.toml to silence this."
+                     ~/.config/bcmr/config.toml to silence this.{sync_caveat}"
                 );
             }
         }

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -117,6 +117,7 @@ pub struct TransferOptions {
     pub resume: bool,
     pub strict: bool,
     pub append: bool,
+    pub sync: bool,
 }
 
 pub type RemoteTransferOptions = TransferOptions;

--- a/src/core/remote/transfer.rs
+++ b/src/core/remote/transfer.rs
@@ -129,6 +129,12 @@ pub async fn download_file(
         )));
     }
 
+    if opts.sync {
+        dst_file.flush().await?;
+        crate::core::io::durable_sync_async(&dst_file).await?;
+    }
+    drop(dst_file);
+
     if opts.verify {
         let local_path = local_dst.to_path_buf();
         let local_hash =


### PR DESCRIPTION
## Summary

Two semantic-drift fixes surfaced during a Codex-style audit before v0.6.0.

### 1. \`check --exclude\` now symmetric across remote/local
\`collect_local_entries\` filtered via regex through \`traversal::walk\`, but \`collect_remote_entries\` (both serve and legacy) returned raw listings. That made \`bcmr check user@host:/src /dst -e '\.log$'\` report every remote \`.log\` as missing-from-dst.

Fix: \`collect_both\` runs a \`filter_entries\` pass over remote results. Unit tests added.

### 2. \`--sync\` honored on legacy downloads, caveat printed on uploads
Serve path already did fsync (client + server). Legacy \`transfer::download_file\` had zero sync calls — durability silently dropped on fallback.

Fix:
- \`download_file\` now calls \`durable_sync_async\` on the dst file when \`opts.sync\`, before verify/preserve
- \`upload_file\` via scp can't guarantee remote fsync; when \`--sync && is_upload\` triggers fallback, the dispatcher's fallback warning now includes a caveat line
- \`TransferOptions.sync\` added; unifies the previously-separate sibling field on \`CopyFileOptions\`

### Docs
\`docs/guide/remote-copy.md\` + zh + zh-Hant: the serve-resume limitation note rewritten. Single-file serve uploads do resume natively via \`Put{offset}\` since PR #25; only directory uploads and all downloads fall back.

## Test plan
- [x] cargo test --features test-support: 316 passed (2 new)
- [x] cargo clippy --all-targets --features test-support -- -D warnings: clean
- [ ] CI: ubuntu + windows green