### PR TITLE
fix: dispatch remote move via copy + delete-source (#36)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -269,14 +269,70 @@ pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
 }
 
 pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {
+    use crate::core::remote::{parse_remote_path, remote_remove, RemotePath};
+    use crate::ui::display::{print_dry_run, ActionType};
+    use std::path::PathBuf;
+
     let excludes = args.compile_excludes()?;
     let paths = args.get_remove_paths().map_err(anyhow::Error::msg)?;
 
-    let first_display = first_display_name(paths);
+    let mut local_paths: Vec<PathBuf> = Vec::new();
+    let mut remote_paths: Vec<RemotePath> = Vec::new();
+    for p in paths {
+        match parse_remote_path(&p.to_string_lossy()) {
+            Some(r) => {
+                r.reject_unsafe()?;
+                remote_paths.push(r);
+            }
+            None => local_paths.push(p.clone()),
+        }
+    }
+
+    if !remote_paths.is_empty() {
+        if args.is_dry_run() {
+            if !is_json_mode() {
+                println!("DRY RUN MODE: No changes will be made.\n");
+            }
+            for r in &remote_paths {
+                print_dry_run(ActionType::Remove, &r.display(), None);
+            }
+        } else {
+            if !args.is_force()
+                && !args.is_yes()
+                && !crate::app::prompts::confirm_remote_removal(&remote_paths)?
+            {
+                return Err(BcmrError::Cancelled.into());
+            }
+            let recursive = args.is_recursive();
+            let force = args.is_force();
+            let dir_only = args.is_dir_only();
+            for r in &remote_paths {
+                remote_remove(r, recursive, force, dir_only).await?;
+                if args.is_verbose() && !is_json_mode() {
+                    println!("removed {}", r.display());
+                }
+            }
+            if !is_json_mode() {
+                println!(
+                    "Removed {} remote path{}",
+                    remote_paths.len(),
+                    if remote_paths.len() == 1 { "" } else { "s" }
+                );
+            }
+        }
+
+        if local_paths.is_empty() {
+            return Ok(());
+        }
+    }
+
+    let first_display = first_display_name(&local_paths);
     let early = start_scanning_runner(args, "Removing", first_display.as_deref())?;
 
     let files_to_remove =
-        match commands::remove::check_removes(paths, args.is_recursive(), args, &excludes).await {
+        match commands::remove::check_removes(&local_paths, args.is_recursive(), args, &excludes)
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 if let Some(r) = early {
@@ -287,7 +343,7 @@ pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {
         };
 
     if args.is_dry_run() {
-        if !is_json_mode() {
+        if !is_json_mode() && remote_paths.is_empty() {
             println!("DRY RUN MODE: No changes will be made.\n");
         }
 
@@ -304,7 +360,7 @@ pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {
             true,
         )?;
         let result = commands::remove::remove_paths(
-            paths,
+            &local_paths,
             args,
             &excludes,
             Arc::clone(runner.progress()),
@@ -357,7 +413,7 @@ pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {
     )?;
 
     let result = commands::remove::remove_paths(
-        paths,
+        &local_paths,
         args,
         &excludes,
         Arc::clone(runner.progress()),

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -165,8 +165,20 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
 }
 
 pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
+    use crate::core::remote::parse_remote_path;
+
     let excludes = args.compile_excludes()?;
     let (sources, dest) = args.get_sources_and_dest().map_err(anyhow::Error::msg)?;
+
+    let dest_str = dest.to_string_lossy();
+    let remote_dest = parse_remote_path(&dest_str);
+    let any_remote_source = sources
+        .iter()
+        .any(|s| parse_remote_path(&s.to_string_lossy()).is_some());
+
+    if remote_dest.is_some() || any_remote_source {
+        return handle_remote_move(args, sources, dest, &excludes).await;
+    }
 
     if sources.len() > 1 && (!dest.exists() || !dest.is_dir()) {
         bail!(
@@ -266,6 +278,62 @@ pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
     }
 
     runner.finish_ok()
+}
+
+async fn handle_remote_move(
+    args: &Commands,
+    sources: &[std::path::PathBuf],
+    dest: &std::path::Path,
+    excludes: &[regex::Regex],
+) -> Result<()> {
+    use crate::core::remote::{parse_remote_path, remote_remove};
+    use crate::ui::display::{print_dry_run, ActionType};
+
+    handle_remote_copy(args, sources, dest, excludes).await?;
+
+    if args.is_dry_run() {
+        if !is_json_mode() {
+            for src in sources {
+                let label = src.to_string_lossy();
+                print_dry_run(ActionType::Remove, &format!("source {}", label), None);
+            }
+        }
+        return Ok(());
+    }
+
+    let recursive = args.is_recursive();
+    let verbose = args.is_verbose() && !is_json_mode();
+
+    for src in sources {
+        let src_str = src.to_string_lossy();
+        if let Some(remote_src) = parse_remote_path(&src_str) {
+            remote_remove(&remote_src, recursive, false, false).await?;
+            if verbose {
+                println!("removed source {}", remote_src.display());
+            }
+        } else {
+            let md = match src.symlink_metadata() {
+                Ok(m) => m,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Source '{}' vanished after copy: {}",
+                        src.display(),
+                        e
+                    ));
+                }
+            };
+            if md.is_dir() {
+                tokio::fs::remove_dir_all(src).await?;
+            } else {
+                tokio::fs::remove_file(src).await?;
+            }
+            if verbose {
+                println!("removed source '{}'", src.display());
+            }
+        }
+    }
+
+    Ok(())
 }
 
 pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {

--- a/src/app/prompts.rs
+++ b/src/app/prompts.rs
@@ -70,6 +70,17 @@ pub(crate) fn confirm_removal(files: &[commands::remove::FileToRemove]) -> Resul
     prompt_yes_no("\nDo you want to proceed?")
 }
 
+pub(crate) fn confirm_remote_removal(paths: &[crate::core::remote::RemotePath]) -> Result<bool> {
+    if is_json_mode() {
+        return Ok(true);
+    }
+    println!("\nThe following remote paths will be removed:");
+    for r in paths {
+        println!("  REMOTE: {}", r.display());
+    }
+    prompt_yes_no("\nDo you want to proceed?")
+}
+
 pub(crate) fn first_display_name(paths: &[std::path::PathBuf]) -> Option<String> {
     paths.first().map(|p| {
         p.file_name()

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -32,6 +32,15 @@ pub async fn run(
         ));
     }
 
+    if let Some(ref rd) = remote_dest {
+        rd.reject_unsafe()?;
+    }
+    for src in sources {
+        if let Some(rsrc) = parse_remote_path(&src.to_string_lossy()) {
+            rsrc.reject_unsafe()?;
+        }
+    }
+
     let remote_host = if let Some(ref rd) = remote_dest {
         Some(rd.ssh_target())
     } else if any_remote_source {

--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -219,20 +219,6 @@ pub(super) fn resolve_upload_remote(
     }
 }
 
-fn reject_parent_dir_components(remote: &RemotePath) -> Result<()> {
-    if std::path::Path::new(&remote.path)
-        .components()
-        .any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        anyhow::bail!(
-            "remote path '{}' contains '..' — refusing for safety; \
-             this is a hard error on every transport, including the legacy SSH fallback",
-            remote
-        );
-    }
-    Ok(())
-}
-
 pub async fn handle_remote_copy(
     args: &Commands,
     sources: &[std::path::PathBuf],
@@ -244,11 +230,11 @@ pub async fn handle_remote_copy(
     let is_upload = remote_dest.is_some();
 
     if let Some(ref rd) = remote_dest {
-        reject_parent_dir_components(rd)?;
+        rd.reject_unsafe()?;
     }
     for src in sources {
         if let Some(rsrc) = parse_remote_path(&src.to_string_lossy()) {
-            reject_parent_dir_components(&rsrc)?;
+            rsrc.reject_unsafe()?;
         }
     }
 

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -8,8 +8,8 @@ mod transfer;
 pub use attrs::{apply_remote_attrs_locally, preserve_remote_attrs, verify_remote_file};
 #[allow(unused_imports)]
 pub use ops::{
-    complete_remote_path, remote_file_hash, remote_file_size, remote_list_files, remote_stat,
-    remote_total_size, validate_ssh_connection,
+    complete_remote_path, remote_file_hash, remote_file_size, remote_list_files, remote_remove,
+    remote_stat, remote_total_size, validate_ssh_connection,
 };
 pub use resume::{check_resume_state, ResumeDecision};
 pub use transfer::{
@@ -45,6 +45,32 @@ impl RemotePath {
             host: self.host.clone(),
             path: format!("{}/{}", self.path, subpath),
         }
+    }
+
+    pub fn reject_unsafe(&self) -> Result<(), crate::core::error::BcmrError> {
+        let p = std::path::Path::new(&self.path);
+        let mut has_named_component = false;
+        for c in p.components() {
+            match c {
+                std::path::Component::ParentDir => {
+                    return Err(crate::core::error::BcmrError::InvalidInput(format!(
+                        "remote path '{}' contains '..' — refusing for safety; \
+                         this is a hard error on every transport, including the legacy SSH fallback",
+                        self
+                    )));
+                }
+                std::path::Component::Normal(_) => has_named_component = true,
+                _ => {}
+            }
+        }
+        if !has_named_component {
+            return Err(crate::core::error::BcmrError::InvalidInput(format!(
+                "remote path '{}' resolves to the login dir or root — refusing for safety \
+                 (use a non-empty named path)",
+                self
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -219,5 +245,37 @@ mod tests {
     #[test]
     fn test_shell_escape_with_quotes() {
         assert_eq!(super::ssh_cmd::shell_escape("it's"), "it'\\''s");
+    }
+
+    fn rp(path: &str) -> RemotePath {
+        RemotePath {
+            user: None,
+            host: "h".into(),
+            path: path.into(),
+        }
+    }
+
+    #[test]
+    fn reject_unsafe_blocks_parent_dir_components() {
+        assert!(rp("..").reject_unsafe().is_err());
+        assert!(rp("foo/..").reject_unsafe().is_err());
+        assert!(rp("foo/../bar").reject_unsafe().is_err());
+        assert!(rp("../etc/passwd").reject_unsafe().is_err());
+    }
+
+    #[test]
+    fn reject_unsafe_blocks_login_dir_and_root() {
+        assert!(rp("").reject_unsafe().is_err());
+        assert!(rp(".").reject_unsafe().is_err());
+        assert!(rp("./").reject_unsafe().is_err());
+        assert!(rp("/").reject_unsafe().is_err());
+    }
+
+    #[test]
+    fn reject_unsafe_allows_normal_paths() {
+        rp("foo").reject_unsafe().expect("plain name");
+        rp("foo/bar.txt").reject_unsafe().expect("nested name");
+        rp("./foo").reject_unsafe().expect("cur-prefixed name");
+        rp("/etc/passwd").reject_unsafe().expect("absolute name");
     }
 }

--- a/src/core/remote/ops.rs
+++ b/src/core/remote/ops.rs
@@ -177,6 +177,38 @@ pub async fn remote_file_hash(
     Ok(hasher.finalize().to_hex().to_string())
 }
 
+pub async fn remote_remove(
+    remote: &RemotePath,
+    recursive: bool,
+    force: bool,
+    dir_only: bool,
+) -> Result<(), BcmrError> {
+    let target = remote.ssh_target();
+    let escaped = shell_escape(&remote.path);
+    let cmd = if dir_only {
+        format!("rmdir -- '{}'", escaped)
+    } else {
+        let flags = match (recursive, force) {
+            (true, true) => " -rf",
+            (true, false) => " -r",
+            (false, true) => " -f",
+            (false, false) => "",
+        };
+        format!("rm{} -- '{}'", flags, escaped)
+    };
+
+    let output = ssh_command(&target).arg(&cmd).output().await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(BcmrError::InvalidInput(ssh_error_message(
+            &stderr,
+            &format!("Cannot remove remote path '{}'", remote),
+        )));
+    }
+    Ok(())
+}
+
 pub async fn complete_remote_path(partial: &str) -> Vec<String> {
     let remote = match parse_remote_path(partial) {
         Some(r) => r,


### PR DESCRIPTION
## Summary
- `bcmr move host:src dst` and `bcmr move src host:dst` were both broken: `handle_move_command` had no `parse_remote_path` step, so the literal `host:...` PathBuf was passed straight to local `move_path`, which `fs::metadata`'s it and reports misleading errors ("No such file or directory" on push, "Source not found" on pull).
- Mirror `handle_copy_command`'s branching: when any source or dest is remote, route to `handle_remote_move`, which delegates the transfer to `handle_remote_copy` (already correct for both directions) and then removes each source — remote ones via `remote_remove`, local ones via `tokio::fs::remove_*`.
- Dry-run skips the deletion step. Verbose prints `removed source <path>` per source.

## Depends on
#50 — uses `remote_remove` introduced there. Merge #50 first; this branch will rebase cleanly onto main.

## Test plan
- [x] `bcmr move /local/file HOST:dst/` (push): file uploaded, local source deleted (verified on 4090_j).
- [x] `bcmr move HOST:src.txt /local/dst/` (pull): file downloaded, remote source deleted (verified on 4090_j).
- [x] `bcmr move -r /local/dir HOST:dst/` (recursive push): tree uploaded, local dir removed.
- [x] `bcmr move --dry-run /local/file HOST:dst/`: dry-run output prints, local file untouched.
- [x] `cargo test --lib` (71 passed).

Closes #36