### PR TITLE
fix: gate Put{offset} resume on CAP_PUT_OFFSET (#44)

### DIFF
--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -150,10 +150,20 @@ pub(super) async fn handle_serve_upload(
                 (runner.inc_callback())(size);
                 continue;
             }
-            let offset = match resume_offset {
+            let mut offset = match resume_offset {
                 Some(UploadDecision::Append(o)) => o,
                 _ => 0,
             };
+            if offset > 0 && !pool.first_mut().supports_put_offset() {
+                if !crate::config::is_json_mode() {
+                    eprintln!(
+                        "bcmr: remote server does not advertise CAP_PUT_OFFSET; \
+                         re-uploading '{}' from scratch (resume not supported by this server)",
+                        src.display()
+                    );
+                }
+                offset = 0;
+            }
 
             let use_stripe = args.use_direct_tcp()
                 && pool.len() > 1

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,5 +1,5 @@
 use crate::core::protocol::{
-    CAP_AEAD, CAP_DEDUP, CAP_DIRECT_TCP, CAP_FAST, CAP_LZ4, CAP_SYNC, CAP_ZSTD,
+    CAP_AEAD, CAP_DEDUP, CAP_DIRECT_TCP, CAP_FAST, CAP_LZ4, CAP_PUT_OFFSET, CAP_SYNC, CAP_ZSTD,
 };
 use anyhow::{bail, Result};
 use std::path::{Path, PathBuf};
@@ -9,8 +9,14 @@ mod handlers;
 mod rendezvous;
 mod session;
 
-pub(super) const SERVER_CAPS: u8 =
-    CAP_LZ4 | CAP_ZSTD | CAP_DEDUP | CAP_FAST | CAP_SYNC | CAP_DIRECT_TCP | CAP_AEAD;
+pub(super) const SERVER_CAPS: u8 = CAP_LZ4
+    | CAP_ZSTD
+    | CAP_DEDUP
+    | CAP_FAST
+    | CAP_SYNC
+    | CAP_DIRECT_TCP
+    | CAP_AEAD
+    | CAP_PUT_OFFSET;
 
 fn resolve_root(arg: Option<PathBuf>) -> Result<PathBuf> {
     let raw = match arg {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -47,6 +47,8 @@ pub const CAP_DIRECT_TCP: u8 = 0x20;
 
 pub const CAP_AEAD: u8 = 0x40;
 
+pub const CAP_PUT_OFFSET: u8 = 0x80;
+
 pub const CAP_LZ4: u8 = 0x01;
 pub const CAP_ZSTD: u8 = 0x02;
 

--- a/src/core/serve_client.rs
+++ b/src/core/serve_client.rs
@@ -8,7 +8,8 @@ use crate::core::compress;
 use crate::core::error::BcmrError;
 use crate::core::framing::{self, RecvHalf, SendHalf};
 use crate::core::protocol::{
-    CompressionAlgo, Message, CAP_AEAD, CAP_DEDUP, CAP_LZ4, CAP_ZSTD, PROTOCOL_VERSION,
+    CompressionAlgo, Message, CAP_AEAD, CAP_DEDUP, CAP_LZ4, CAP_PUT_OFFSET, CAP_ZSTD,
+    PROTOCOL_VERSION,
 };
 use crate::core::protocol_aead::Direction;
 use crate::core::transport::ssh as ssh_transport;
@@ -31,7 +32,7 @@ struct Transport {
     _drain: Option<tokio::task::JoinHandle<()>>,
 }
 
-const CLIENT_CAPS: u8 = CAP_LZ4 | CAP_ZSTD | CAP_DEDUP;
+const CLIENT_CAPS: u8 = CAP_LZ4 | CAP_ZSTD | CAP_DEDUP | CAP_PUT_OFFSET;
 
 const DEDUP_MIN_FILE_SIZE: u64 = 16 * 1024 * 1024;
 const DEDUP_BLOCK_SIZE: usize = 4 * 1024 * 1024;
@@ -44,6 +45,7 @@ pub struct ServeClient {
     rx: RecvHalf,
     algo: CompressionAlgo,
     dedup_enabled: bool,
+    effective_caps: u8,
     poisoned: bool,
 }
 
@@ -79,8 +81,13 @@ impl ServeClient {
             rx,
             algo: CompressionAlgo::None,
             dedup_enabled: false,
+            effective_caps: 0,
             poisoned: false,
         }
+    }
+
+    pub fn supports_put_offset(&self) -> bool {
+        self.effective_caps & CAP_PUT_OFFSET != 0
     }
 
     async fn handshake(&mut self, caps: u8) -> Result<(), BcmrError> {
@@ -104,6 +111,7 @@ impl ServeClient {
                 let effective = caps & server_caps;
                 self.algo = CompressionAlgo::negotiate(caps, server_caps);
                 self.dedup_enabled = (effective & CAP_DEDUP) != 0;
+                self.effective_caps = effective;
                 if (effective & CAP_AEAD) != 0 {
                     let key = session_key.ok_or_else(|| {
                         BcmrError::CryptoFailure(

--- a/src/core/serve_client/promote.rs
+++ b/src/core/serve_client/promote.rs
@@ -160,6 +160,7 @@ impl ServeClient {
             rx,
             algo: CompressionAlgo::None,
             dedup_enabled: false,
+            effective_caps: 0,
             poisoned: false,
         };
 


### PR DESCRIPTION
## Summary
- `bcmr copy -C` against any server that pre-dates Put{offset} (added in #25 without bumping `PROTOCOL_VERSION` or adding a cap) silently produced a truncated, shifted destination: old servers ignore the trailing offset bytes, run the original create+truncate handler, then receive source bytes streamed from offset N — final file is `src[N:]`, size `src - N`.
- Add `CAP_PUT_OFFSET (0x80)`. Servers that implement the offset-aware `handle_put` advertise it; clients only call `put_at` when negotiation confirms both ends understand the new wire shape.
- When the cap is missing, the client warns and falls back to a full re-upload via `put` — losing the resume optimization, preserving correctness.

## Reproduced + verified on 4090_j (server 0.5.20)
| | size | hash matches source |
|---|---|---|
| Pre-fix repro (24 MiB partial → 64 MiB src) | 8 MiB ❌ | no ❌ |
| Post-fix (warning fires, full re-upload) | 64 MiB ✅ | yes ✅ |

## Compat
- New client + new server: full optimization (negotiate cap → put_at).
- New client + old server (most users today): warning + full re-upload, correct data.
- Old client + any server: unchanged (the bug is unfixable client-side without an upgrade — that's why this is a client-side fix users adopt by upgrading).

## Test plan
- [x] Reproduced original bug on 4090_j (0.5.20 server) with the released binary; final file 8 MiB hash mismatch.
- [x] Verified post-fix: warning prints, file is full size and hash-matches source.
- [x] `cargo test --lib` (71 passed).

Closes #44