### PR TITLE
fix: reject '..' in remote paths before transport (#45)

### DIFF
--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -219,6 +219,20 @@ pub(super) fn resolve_upload_remote(
     }
 }
 
+fn reject_parent_dir_components(remote: &RemotePath) -> Result<()> {
+    if std::path::Path::new(&remote.path)
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        anyhow::bail!(
+            "remote path '{}' contains '..' — refusing for safety; \
+             this is a hard error on every transport, including the legacy SSH fallback",
+            remote
+        );
+    }
+    Ok(())
+}
+
 pub async fn handle_remote_copy(
     args: &Commands,
     sources: &[std::path::PathBuf],
@@ -228,6 +242,15 @@ pub async fn handle_remote_copy(
     let dest_str = dest.to_string_lossy();
     let remote_dest = parse_remote_path(&dest_str);
     let is_upload = remote_dest.is_some();
+
+    if let Some(ref rd) = remote_dest {
+        reject_parent_dir_components(rd)?;
+    }
+    for src in sources {
+        if let Some(rsrc) = parse_remote_path(&src.to_string_lossy()) {
+            reject_parent_dir_components(&rsrc)?;
+        }
+    }
 
     let compression_mode = CONFIG.scp.compression.to_lowercase();
     let compress = match compression_mode.as_str() {


### PR DESCRIPTION
## Summary
- The fast path validated `..` per-message in the serve protocol; but `handle_remote_copy` itself never validated the dispatcher arguments. When the fast path declined for any reason (old server, missing daemon, or the policy rejection itself), the client silently fell back to legacy SSH, which built a scp command from the unvalidated remote string and let the remote shell resolve `..` — turning every fallback into an arbitrary-file-read on the remote.
- Reject `ParentDir` components on every remote source/dest at the entry of `handle_remote_copy`, before any transport runs. The legacy-fallback decision can now stay strictly about transport availability; policy errors no longer leak through it.

## Repro / verification on 4090_j (server 0.5.20, fast path rejects `..` then falls back)
```
$ ./target/debug/bcmr copy '4090_j:../../../../etc/passwd' /tmp/loot/
Error: remote path '4090_j:../../../../etc/passwd' contains '..' — refusing for safety;
       this is a hard error on every transport, including the legacy SSH fallback
$ echo $?
1
$ ls /tmp/loot/        # empty
```

Pre-fix: `head /tmp/loot/passwd` returned the real `/etc/passwd` from 4090.

## Test plan
- [x] `bcmr copy 'host:../../../etc/passwd' /tmp/loot/` rejected with exit 1, nothing written.
- [x] Legitimate `bcmr copy /local/file host:dst/file` still succeeds (no false positives on normal paths).
- [x] `cargo test --lib` (71 passed).

Closes #45