### PR TITLE
fix: --append refuses incompatible destinations (#52)

### DIFF
--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -305,6 +305,9 @@ pub async fn handle_remote_copy(
         Ok(()) => return Ok(()),
         Err(e) => {
             let msg = e.to_string();
+            if msg.contains("--append refused:") {
+                return Err(e);
+            }
             let is_dry_run_redirect = msg.contains("dry-run fallback");
             let is_resume_redirect = msg.contains("not yet supported, fallback to legacy")
                 || msg.contains("not supported, fallback to legacy");

--- a/src/core/remote/resume.rs
+++ b/src/core/remote/resume.rs
@@ -1,6 +1,7 @@
 use super::RemoteTransferOptions;
 use crate::core::error::BcmrError;
 
+#[derive(Debug)]
 pub struct ResumeDecision {
     pub skip_bytes: u64,
     pub use_append_mode: bool,
@@ -15,23 +16,25 @@ pub async fn check_resume_state(
     source_full_hash: impl AsyncFnOnce() -> Result<String, BcmrError>,
     source_partial_hash: impl AsyncFnOnce(u64) -> Result<String, BcmrError>,
 ) -> Result<ResumeDecision, BcmrError> {
+    let no_resume = ResumeDecision {
+        skip_bytes: 0,
+        use_append_mode: false,
+        skip_entirely: false,
+    };
+
     if !(opts.resume || opts.append || opts.strict) {
-        return Ok(ResumeDecision {
-            skip_bytes: 0,
-            use_append_mode: false,
-            skip_entirely: false,
-        });
+        return Ok(no_resume);
     }
 
     let existing_size = match existing_size {
         Some(s) => s,
-        None => {
-            return Ok(ResumeDecision {
-                skip_bytes: 0,
-                use_append_mode: false,
-                skip_entirely: false,
-            })
-        }
+        None => return Ok(no_resume),
+    };
+
+    let refuse = |reason: String| {
+        Err(BcmrError::InvalidInput(format!(
+            "--append refused: {reason} (use --resume to overwrite, or remove the flag)"
+        )))
     };
 
     if existing_size == source_size {
@@ -44,11 +47,12 @@ pub async fn check_resume_state(
                 skip_entirely: true,
             });
         }
-        return Ok(ResumeDecision {
-            skip_bytes: 0,
-            use_append_mode: false,
-            skip_entirely: false,
-        });
+        if opts.append {
+            return refuse(format!(
+                "destination has the same size ({source_size}) but different content"
+            ));
+        }
+        return Ok(no_resume);
     } else if existing_size < source_size {
         let ex_hash = existing_full_hash().await?;
         let partial = source_partial_hash(existing_size).await?;
@@ -59,18 +63,20 @@ pub async fn check_resume_state(
                 skip_entirely: false,
             });
         }
-        return Ok(ResumeDecision {
-            skip_bytes: 0,
-            use_append_mode: false,
-            skip_entirely: false,
-        });
+        if opts.append {
+            return refuse(format!(
+                "destination's first {existing_size} bytes do not match source"
+            ));
+        }
+        return Ok(no_resume);
     }
 
-    Ok(ResumeDecision {
-        skip_bytes: 0,
-        use_append_mode: false,
-        skip_entirely: false,
-    })
+    if opts.append {
+        return refuse(format!(
+            "destination is larger ({existing_size}) than source ({source_size})"
+        ));
+    }
+    Ok(no_resume)
 }
 
 #[cfg(test)]
@@ -103,7 +109,7 @@ mod tests {
     #[tokio::test]
     async fn test_check_resume_state_shorter_prefix_requires_hash_match() {
         let opts = RemoteTransferOptions {
-            append: true,
+            resume: true,
             ..Default::default()
         };
 
@@ -144,5 +150,83 @@ mod tests {
         assert!(!decision.skip_entirely);
         assert_eq!(decision.skip_bytes, 512);
         assert!(decision.use_append_mode);
+    }
+
+    #[tokio::test]
+    async fn append_refuses_when_existing_larger_than_source() {
+        let opts = RemoteTransferOptions {
+            append: true,
+            ..Default::default()
+        };
+        let err = check_resume_state(
+            &opts,
+            Some(2048),
+            1024,
+            async || Ok("unused".into()),
+            async || Ok("unused".into()),
+            async |_| Ok("unused".into()),
+        )
+        .await
+        .expect_err("must refuse");
+        assert!(err.to_string().contains("destination is larger"));
+    }
+
+    #[tokio::test]
+    async fn append_refuses_when_prefix_diverges() {
+        let opts = RemoteTransferOptions {
+            append: true,
+            ..Default::default()
+        };
+        let err = check_resume_state(
+            &opts,
+            Some(512),
+            1024,
+            async || Ok("ex".into()),
+            async || Ok("unused".into()),
+            async |_| Ok("src-prefix".into()),
+        )
+        .await
+        .expect_err("must refuse");
+        assert!(err.to_string().contains("first 512 bytes do not match"));
+    }
+
+    #[tokio::test]
+    async fn append_refuses_when_same_size_but_different_content() {
+        let opts = RemoteTransferOptions {
+            append: true,
+            ..Default::default()
+        };
+        let err = check_resume_state(
+            &opts,
+            Some(1024),
+            1024,
+            async || Ok("ex".into()),
+            async || Ok("src".into()),
+            async |_| Ok("unused".into()),
+        )
+        .await
+        .expect_err("must refuse");
+        assert!(err.to_string().contains("same size"));
+    }
+
+    #[tokio::test]
+    async fn resume_still_overwrites_on_mismatch() {
+        let opts = RemoteTransferOptions {
+            resume: true,
+            ..Default::default()
+        };
+        let decision = check_resume_state(
+            &opts,
+            Some(2048),
+            1024,
+            async || Ok("ex".into()),
+            async || Ok("unused".into()),
+            async |_| Ok("unused".into()),
+        )
+        .await
+        .expect("resume must not refuse");
+        assert!(!decision.skip_entirely);
+        assert_eq!(decision.skip_bytes, 0);
+        assert!(!decision.use_append_mode);
     }
 }


### PR DESCRIPTION
## Summary
With #44's `CAP_PUT_OFFSET` fallback merged, the original repro's "claims success but never wrote" cases (B / C in the matrix) now upload correctly. What's left is the matrix's destructive cases — `check_resume_state` collapsed every "no clean resume" condition into a default "fall through to overwrite" decision, so under `--append` a divergent or oversized remote was silently truncated/replaced rather than refused.

| Case | Source | Remote before | Remote after (pre-fix) | Now |
|---|---|---|---|---|
| A | 4 B | 4 B same | unchanged | unchanged ✓ |
| B | 11 B | 5 B prefix | unchanged ❌ | 11 B append ✓ (#44) |
| C | 14 B | missing | unchanged ❌ | 14 B created ✓ (#44) |
| D | 3 B | 16 B (larger) | **truncated to 3 B** ❌ | refuses ✓ (this PR) |
| E | 7 B | 3 B diverge | **overwritten** ❌ | refuses ✓ (this PR) |

## Behavior change
Under `--append` (only — `--resume` / `--strict` are unchanged), `check_resume_state` now returns `Err` when the remote isn't a clean append candidate:
- `existing > source size` → "destination is larger ({n}) than source ({m})"
- `existing == source size` but full hashes differ → "destination has the same size ({n}) but different content"
- `existing < source size` but prefix hashes diverge → "destination's first {n} bytes do not match source"

Each error names `--resume` as the explicit override.

`handle_remote_copy` recognises the `--append refused:` sentinel and skips both the legacy retry and the fallback warning — policy refusals shouldn't look like transport failures.

## Verified live on 4090_j (server 0.5.20, drives the legacy fallback path):

```
$ ./target/debug/bcmr copy -a /tmp/s.txt 4090_j:r4/big.txt   # 3B src, 16B dst
Error: Invalid input: --append refused: destination is larger (16) than source (3) (use --resume to overwrite, or remove the flag)

$ ssh 4090_j 'stat -c %s ~/r4/big.txt'
16              # unchanged
```

All five cases (A–E) re-tested end-to-end on the same host.

## Test plan
- [x] 5 new unit tests cover the refusal paths and a regression guard for `--resume` (still overwrites on mismatch).
- [x] `cargo test --lib` 78 passed.
- [x] Manual end-to-end of all 5 cases on 4090_j (0.5.20 server).

Closes #52