### PR TITLE
fix: error on copy DIR DST without -r instead of silent 0 B (#58)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -35,6 +35,19 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
         return handle_remote_copy(args, sources, dest, &excludes).await;
     }
 
+    if !args.is_recursive() {
+        for src in sources {
+            if let Ok(md) = src.symlink_metadata() {
+                if md.is_dir() {
+                    bail!(
+                        "Source '{}' is a directory. Use -r flag for recursive copy.",
+                        src.display()
+                    );
+                }
+            }
+        }
+    }
+
     if sources.len() > 1 && (!dest.exists() || !dest.is_dir()) {
         bail!(
             "When copying multiple sources, destination '{}' must be an existing directory",

--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -235,6 +235,15 @@ pub async fn handle_remote_copy(
     for src in sources {
         if let Some(rsrc) = parse_remote_path(&src.to_string_lossy()) {
             rsrc.reject_unsafe()?;
+            continue;
+        }
+        if let Ok(md) = src.symlink_metadata() {
+            if md.is_dir() && !args.is_recursive() {
+                anyhow::bail!(
+                    "Source '{}' is a directory. Use -r flag for recursive copy.",
+                    src.display()
+                );
+            }
         }
     }
 
@@ -305,7 +314,7 @@ pub async fn handle_remote_copy(
         Ok(()) => return Ok(()),
         Err(e) => {
             let msg = e.to_string();
-            if msg.contains("--append refused:") {
+            if msg.contains("--append refused:") || msg.contains("Use -r flag for recursive copy") {
                 return Err(e);
             }
             let is_dry_run_redirect = msg.contains("dry-run fallback");

--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -222,6 +222,12 @@ pub(super) async fn handle_serve_upload(
                 ));
             }
             serve_upload_dir(&mut pool, src, rdest, &runner, excludes, args).await?;
+        } else if src.is_dir() {
+            pool.close().await?;
+            bail!(
+                "Source '{}' is a directory. Use -r flag for recursive copy.",
+                src.display()
+            );
         }
     }
 
@@ -343,6 +349,13 @@ pub(super) async fn handle_serve_download(
         let src_str = src.to_string_lossy();
         if let Some(rp) = parse_remote_path(&src_str) {
             let (size, _mtime, is_dir) = pool.first_mut().stat(&rp.path).await?;
+            if is_dir && !args.is_recursive() {
+                pool.close().await?;
+                bail!(
+                    "Remote source '{}' is a directory. Use -r flag for recursive copy.",
+                    rp
+                );
+            }
             if is_dir && args.is_recursive() {
                 let entries = pool.first_mut().list(&rp.path).await?;
                 let dir_name = rp.path.rsplit('/').next().unwrap_or(&rp.path);


### PR DESCRIPTION
## Summary
Three independent silent-skip paths converged on the same `Done: 0 B` output:
- **Local pipeline**: `handle_copy_command`'s no-overwrite branch built the runner first and called `pipeline_copy`. The pipeline did error, but `ProgressRenderer::finish_err`'s default impl falls through to `finish()`, which prints the success line — so users saw `Done: 0 B` then `Error:` afterwards.
- **Serve upload**: the `for src in sources` loop had `if is_file() { … } else if is_dir() && is_recursive() { … }` and **no else**, so a dir without `-r` was silently skipped, the pool closed, and `finish_ok()` printed success.
- **Serve download**: stat'd the remote, then took a non-recursive branch only when `is_dir == false` — remote dirs without `-r` produced an empty plan that completed cleanly.

## Fix
Validate up front, in three places:
- `handle_copy_command` rejects local dir sources before constructing the runner.
- `handle_remote_copy` entry rejects local dir sources alongside the existing `reject_unsafe` walk.
- Serve upload's loop and serve download's stat branch bail when a dir source meets no `-r`.

Recognise `Use -r flag for recursive copy` in `handle_remote_copy`'s fallback-skip sentinels so policy errors don't trip the legacy retry + fallback warning banner (same pattern as `--append refused:` from #64).

## Verified on 4090_j
| Case | Pre-fix | Now |
|---|---|---|
| `bcmr copy /local/dir /local/dst/` | `Done: 0 B` then `Error:` | clean `Error:` only, exit 1 |
| `bcmr copy /local/dir 4090_j:dst/` | `Done: 0 B` exit 0 (silent) | clean `Error:` exit 1 |
| `bcmr copy 4090_j:dst/srcdir /local/` | silent fallback path | clean `Error:` exit 1 |
| `bcmr copy -r /local/dir 4090_j:dst/` (sanity) | works | works |

## Test plan
- [x] `cargo test --lib` 74 passed.
- [x] All four cases above end-to-end on 4090_j (server 0.5.20).

Closes #58