### PR TITLE
fix: append basename in legacy single-file upload to host:dir/ (#37)

### DIFF
--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -212,7 +212,7 @@ pub(super) fn resolve_upload_remote(
     rdest: &RemotePath,
     multi_source: bool,
 ) -> RemotePath {
-    if multi_source || rdest.path == "." {
+    if multi_source || rdest.path == "." || rdest.path.ends_with('/') {
         rdest.join(&src.file_name().unwrap_or_default().to_string_lossy())
     } else {
         rdest.clone()

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -40,10 +40,15 @@ impl RemotePath {
     }
 
     pub fn join(&self, subpath: &str) -> Self {
+        let path = if self.path.ends_with('/') {
+            format!("{}{}", self.path, subpath)
+        } else {
+            format!("{}/{}", self.path, subpath)
+        };
         Self {
             user: self.user.clone(),
             host: self.host.clone(),
-            path: format!("{}/{}", self.path, subpath),
+            path,
         }
     }
 
@@ -235,6 +240,16 @@ mod tests {
         let joined = r.join("sub/file.txt");
         assert_eq!(joined.path, "/base/sub/file.txt");
         assert_eq!(joined.host, "h");
+    }
+
+    #[test]
+    fn join_does_not_double_slash_when_base_has_trailing_slash() {
+        let r = RemotePath {
+            user: None,
+            host: "h".to_string(),
+            path: "dst/".to_string(),
+        };
+        assert_eq!(r.join("file.txt").path, "dst/file.txt");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `resolve_upload_remote` only appended the source basename for multi-source calls or `rdest.path == "."`. The trailing-slash convention (`host:dir/` as a directory hint, matching `cp`/`scp`) was ignored — the literal `dst/` made it into the `cat > 'dst/'` redirection and the remote shell errored with "Is a directory". Recursive uploads worked only because they walk per-file and call `rdest.join()` themselves.
- Treat trailing slash as the directory-target signal in `resolve_upload_remote`, and tighten `RemotePath::join` so it doesn't double the slash when the base already has one (also closes the cosmetic double-slash in `bcmr copy -r -n` dry-run output, #56).

## Verified on lunemira_sv (no remote bcmr — legacy fallback only)
| Case | Pre-fix | Now |
|---|---|---|
| `bcmr copy /tmp/small.txt host:dst/` | `dst/: Is a directory` | uploads as `dst/small.txt` ✓ |
| `bcmr copy /tmp/small.txt host:dst/explicit.txt` | works | works ✓ |
| `bcmr copy -r /tmp/rdir host:dst/` | works (but `host:dst//rel` in dry-run) | works, no double slash ✓ |

## Test plan
- [x] New unit test for join with trailing slash. `cargo test --lib` 75 passed.
- [x] All three cases above end-to-end on lunemira_sv.

Closes #37
Closes #56