### PR TITLE
fix: share ControlMaster across legacy workers (#38)

### DIFF
--- a/src/core/remote/ssh_cmd.rs
+++ b/src/core/remote/ssh_cmd.rs
@@ -43,52 +43,8 @@ pub(super) fn ssh_base_args(target: &str) -> Vec<String> {
     args
 }
 
-pub(super) fn ssh_base_args_for_worker(target: &str, worker_id: usize) -> Vec<String> {
-    let dir = std::env::temp_dir().join("bcmr-ssh");
-    let _ = std::fs::create_dir_all(&dir);
-    let cp = dir
-        .join(format!(
-            "w{}_{}.sock",
-            worker_id,
-            target.replace(['@', ':', '/'], "_")
-        ))
-        .to_string_lossy()
-        .to_string();
-
-    let mut args = vec![
-        "-o".into(),
-        format!("ControlPath={}", cp),
-        "-o".into(),
-        "ControlMaster=auto".into(),
-        "-o".into(),
-        "ControlPersist=60".into(),
-        "-o".into(),
-        "ConnectTimeout=10".into(),
-    ];
-    if !is_interactive() {
-        args.extend(["-o".into(), "BatchMode=yes".into()]);
-    }
-    if SSH_COMPRESS.load(Ordering::Relaxed) {
-        args.extend(["-o".into(), "Compression=yes".into()]);
-    }
-    args
-}
-
-pub(super) fn ssh_command_for_worker(target: &str, worker_id: usize) -> Command {
-    let args = ssh_base_args_for_worker(target, worker_id);
-    let mut cmd = Command::new("ssh");
-    for arg in &args {
-        cmd.arg(arg);
-    }
-    cmd.arg(target);
-    cmd
-}
-
-pub(super) fn make_ssh_cmd(target: &str, worker_id: Option<usize>) -> Command {
-    match worker_id {
-        Some(id) => ssh_command_for_worker(target, id),
-        None => ssh_command(target),
-    }
+pub(super) fn make_ssh_cmd(target: &str, _worker_id: Option<usize>) -> Command {
+    ssh_command(target)
 }
 
 pub(super) fn ssh_command(target: &str) -> Command {


### PR DESCRIPTION
## Summary
- `ssh_base_args_for_worker` built a per-worker `ControlPath` (`w<id>_<target>.sock`), so each legacy SSH worker had to authenticate independently. Under password-auth + TUI, the workers' prompts landed on a terminal already owned by the redraw loop and the user saw an indefinite hang at 0% with no diagnostic.
- Workers now reuse the same `ControlPath` as the dispatcher's earlier `validate_ssh_connection` call. That establishes the master once, before the TUI takes the terminal — the password prompt fires interactively, and every subsequent worker connects through the master socket and skips auth entirely. OpenSSH multiplexing handles the parallel channels (`MaxSessions` covers the per-host worker count).

## Why per-worker sockets weren't load-bearing
There was no functional reason for the per-worker isolation — OpenSSH multiplexes channels over a single master perfectly well, and the change collapses `ssh_base_args_for_worker` into `ssh_base_args` cleanly. The `worker_id` parameter on `make_ssh_cmd` is kept (callers in `transfer.rs` still pass it) so this PR doesn't ripple into a broader signature refactor.

## Verified
- 4090_j (key-auth, no behavior change): direct cp / mv unaffected.
- lunemira_sv (no remote bcmr → legacy fallback only): multi-file `-r` upload runs four workers off a single master socket, single auth.
- I don't have a password-only host wired up locally, but the structural change is straightforward: the only auth event happens in `validate_ssh_connection` before the TUI exists.

## Test plan
- [x] `cargo test --lib` (74 passed).
- [x] Regression: multi-file legacy upload on lunemira_sv, key-auth copy on 4090_j.
- [ ] Password-auth host end-to-end — would appreciate verification on the user's actual repro target (the bcp-from-pem-host case).

Closes #38