### PR TITLE
fix: auto-degrade progress UI to plain text when stdout is not a TTY (#46)

### DIFF
--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -1,7 +1,9 @@
 use crate::ui::inline::InlineProgress;
 use crate::ui::json::JsonProgress;
+use crate::ui::state::ProgressData;
 use crate::ui::tui::TuiProgress;
-use std::io;
+use crate::ui::utils::format_bytes;
+use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 
 pub trait ProgressRenderer: Send {
@@ -39,6 +41,36 @@ impl ProgressRenderer for SilentProgress {
     }
 }
 
+struct PlainTextProgress {
+    data: ProgressData,
+}
+
+impl PlainTextProgress {
+    fn new(total_bytes: u64) -> Self {
+        Self {
+            data: ProgressData::new(total_bytes),
+        }
+    }
+}
+
+impl ProgressRenderer for PlainTextProgress {
+    fn inc_current(&mut self, delta: u64) {
+        self.data.current_bytes += delta;
+    }
+
+    fn finish(&mut self) -> io::Result<()> {
+        let elapsed = self.data.elapsed();
+        let avg_bps = self.data.average_bytes_per_sec().unwrap_or(0.0);
+        println!(
+            "Done: {} in {:.1}s | avg {}/s",
+            format_bytes(self.data.current_bytes as f64),
+            elapsed.as_secs_f64(),
+            format_bytes(avg_bps),
+        );
+        Ok(())
+    }
+}
+
 pub fn create_renderer(
     total_bytes: u64,
     plain: bool,
@@ -55,6 +87,8 @@ pub fn create_renderer(
         Ok(Box::new(SilentProgress))
     } else if plain {
         Ok(Box::new(InlineProgress::new(total_bytes)?))
+    } else if !std::io::stdout().is_terminal() {
+        Ok(Box::new(PlainTextProgress::new(total_bytes)))
     } else {
         Ok(Box::new(TuiProgress::new(total_bytes)?))
     }


### PR DESCRIPTION
## Summary
`create_renderer`'s default branch always picked `TuiProgress`, so `bcmr copy … | cat` (or any non-TTY stdout) ate the cursor / position ANSI codes verbatim. README has long advertised "plain text mode for logs and pipes" — nothing was wired up; the only escape was `-t/--tui` which counter-intuitively *enables* inline mode.

Add `PlainTextProgress` — swallows mid-flight redraws, emits one ASCII summary line at finish (`Done: <bytes> in <secs> | avg <speed>`, mirroring `TuiProgress::finish`). Gate `TuiProgress` on `std::io::stdout().is_terminal()`; when stdout isn't a TTY, fall back to the plain renderer. `-t/--tui` still routes to `InlineProgress` for users who want the 3-line inline UI in a TTY.

## Verified

```
$ ./target/debug/bcmr copy /tmp/x46.txt 4090_j:dst46/x.txt 2>&1 | xxd | head -3
00000000: 446f 6e65 3a20 3520 4220 696e 2030 2e31  Done: 5 B in 0.1
00000010: 7320 7c20 6176 6720 3539 2042 2f73 0a    s | avg 59 B/s.
```
Pure ASCII, no escape bytes. Interactive TTY run still renders the full TUI box.

## Test plan
- [x] `cargo test --lib` 79 passed.
- [x] xxd of piped stdout: zero ANSI bytes, single summary line.
- [x] xxd of file-redirected stdout: same.
- [x] Interactive TTY run on 4090_j: full TUI as before.

Closes #46