### PR TITLE
fix: honor NO_COLOR and TERM=dumb in progress UI (#55)

### DIFF
--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -71,6 +71,14 @@ impl ProgressRenderer for PlainTextProgress {
     }
 }
 
+fn ansi_disabled_by_env() -> bool {
+    let no_color = std::env::var_os("NO_COLOR")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    let dumb_term = matches!(std::env::var("TERM").as_deref(), Ok("dumb"));
+    no_color || dumb_term
+}
+
 pub fn create_renderer(
     total_bytes: u64,
     plain: bool,
@@ -85,10 +93,10 @@ pub fn create_renderer(
         }
     } else if silent {
         Ok(Box::new(SilentProgress))
+    } else if ansi_disabled_by_env() || !std::io::stdout().is_terminal() {
+        Ok(Box::new(PlainTextProgress::new(total_bytes)))
     } else if plain {
         Ok(Box::new(InlineProgress::new(total_bytes)?))
-    } else if !std::io::stdout().is_terminal() {
-        Ok(Box::new(PlainTextProgress::new(total_bytes)))
     } else {
         Ok(Box::new(TuiProgress::new(total_bytes)?))
     }


### PR DESCRIPTION
## Summary
Route `NO_COLOR` / `TERM=dumb` to `PlainTextProgress` (added in #84/#46) so the env vars actually mean "no ANSI."

The issue suggested routing env-var-set users to `effective_plain → InlineProgress`, but `InlineProgress` still drives `crossterm::cursor::MoveUp` and `Clear(CurrentLine)` mid-flight — non-zero ANSI residue. `PlainTextProgress` is silent until `finish()` and emits one ASCII line; that's the actual "no terminal control" mode the spec asks for.

## Spec alignment
- `NO_COLOR` per https://no-color.org/: set-and-non-empty suppresses; empty is treated as unset.
- `TERM=dumb` gates on the literal `"dumb"`.
- Env check sits *above* the `plain` flag — `NO_COLOR=1 bcmr -t copy …` defers to env (matching no-color.org's "env trumps tool flags" guidance).
- `CLICOLOR` intentionally not honored (GNU-specific, not part of the no-color spec; cargo / gh / rg don't read it either).

## Verified matrix (TTY, `xxd` first 32 bytes of stdout)

| env | first bytes | result |
|---|---|---|
| (unset) | `1b5b 366e 1b5b 3f32 356c …` | TUI ANSI ✓ |
| `NO_COLOR=1` | `446f 6e65 3a20 3520 4220 696e …` | `Done:` clean ✓ |
| `TERM=dumb` | `446f 6e65 3a20 3520 4220 696e …` | `Done:` clean ✓ |
| `NO_COLOR=" "` | `446f 6e65 3a …` | `Done:` clean ✓ (set-non-empty) |
| `NO_COLOR=""` | `1b5b 366e …` | TUI ANSI ✓ (empty = unset per spec) |
| `CLICOLOR=0` | `1b5b 366e …` | TUI ANSI ✓ (not honored, by design) |

## Depends on
#84 (#46) — uses the `PlainTextProgress` renderer added there. Will rebase cleanly once #84 lands.

## Test plan
- [x] Six-row matrix above on 4090_j.
- [x] `cargo test --lib` 79 passed.

Closes #55