### PR TITLE
fix: expand ~ and ~user in remote paths via SSH probe (#61, closes #39)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -361,8 +361,9 @@ pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {
     let mut remote_paths: Vec<RemotePath> = Vec::new();
     for p in paths {
         match parse_remote_path(&p.to_string_lossy()) {
-            Some(r) => {
+            Some(mut r) => {
                 r.reject_unsafe()?;
+                r.expand_tilde().await?;
                 remote_paths.push(r);
             }
             None => local_paths.push(p.clone()),

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -41,6 +41,26 @@ pub async fn run(
         }
     }
 
+    let expanded_dest_buf: PathBuf = if let Some(mut rd) = remote_dest.clone() {
+        rd.expand_tilde().await?;
+        PathBuf::from(rd.display())
+    } else {
+        dest.to_path_buf()
+    };
+    let mut expanded_sources: Vec<PathBuf> = Vec::with_capacity(sources.len());
+    for src in sources {
+        if let Some(mut rsrc) = parse_remote_path(&src.to_string_lossy()) {
+            rsrc.expand_tilde().await?;
+            expanded_sources.push(PathBuf::from(rsrc.display()));
+        } else {
+            expanded_sources.push(src.clone());
+        }
+    }
+    let sources: &[PathBuf] = &expanded_sources;
+    let dest: &Path = expanded_dest_buf.as_path();
+    let dest_str = dest.to_string_lossy();
+    let remote_dest = parse_remote_path(&dest_str);
+
     let remote_host = if let Some(ref rd) = remote_dest {
         Some(rd.ssh_target())
     } else if any_remote_source {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -2,8 +2,13 @@ use anyhow::{bail, Result};
 use tokio::process::Command;
 
 pub async fn run(target: &str, remote_path: &str) -> Result<()> {
-    let display_path = remote_path.replace("~", "$HOME");
-    eprintln!("Deploying bcmr to {}:{}", target, display_path);
+    let remote_path_owned = if remote_path.starts_with('~') {
+        crate::core::remote::expand_remote_tilde(target, remote_path).await?
+    } else {
+        remote_path.to_string()
+    };
+    let remote_path = remote_path_owned.as_str();
+    eprintln!("Deploying bcmr to {}:{}", target, remote_path);
 
     let check = ssh(target, "bcmr --version 2>/dev/null || echo NOTFOUND").await?;
     if !check.contains("NOTFOUND") {

--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -226,10 +226,10 @@ pub async fn handle_remote_copy(
     excludes: &[regex::Regex],
 ) -> Result<()> {
     let dest_str = dest.to_string_lossy();
-    let remote_dest = parse_remote_path(&dest_str);
-    let is_upload = remote_dest.is_some();
+    let remote_dest_initial = parse_remote_path(&dest_str);
+    let is_upload = remote_dest_initial.is_some();
 
-    if let Some(ref rd) = remote_dest {
+    if let Some(ref rd) = remote_dest_initial {
         rd.reject_unsafe()?;
     }
     for src in sources {
@@ -246,6 +246,26 @@ pub async fn handle_remote_copy(
             }
         }
     }
+
+    let expanded_dest_buf: PathBuf = if let Some(mut rd) = remote_dest_initial.clone() {
+        rd.expand_tilde().await?;
+        PathBuf::from(rd.display())
+    } else {
+        dest.to_path_buf()
+    };
+    let mut expanded_sources: Vec<PathBuf> = Vec::with_capacity(sources.len());
+    for src in sources {
+        if let Some(mut rsrc) = parse_remote_path(&src.to_string_lossy()) {
+            rsrc.expand_tilde().await?;
+            expanded_sources.push(PathBuf::from(rsrc.display()));
+        } else {
+            expanded_sources.push(src.clone());
+        }
+    }
+    let sources: &[PathBuf] = &expanded_sources;
+    let dest: &std::path::Path = expanded_dest_buf.as_path();
+    let dest_str = dest.to_string_lossy();
+    let remote_dest = parse_remote_path(&dest_str);
 
     let compression_mode = CONFIG.scp.compression.to_lowercase();
     let compress = match compression_mode.as_str() {

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -8,8 +8,9 @@ mod transfer;
 pub use attrs::{apply_remote_attrs_locally, preserve_remote_attrs, verify_remote_file};
 #[allow(unused_imports)]
 pub use ops::{
-    complete_remote_path, remote_file_hash, remote_file_size, remote_list_files, remote_remove,
-    remote_stat, remote_total_size, validate_ssh_connection,
+    complete_remote_path, expand_remote_tilde, remote_file_hash, remote_file_size,
+    remote_list_files, remote_remove, remote_stat, remote_total_size, resolve_remote_home,
+    validate_ssh_connection,
 };
 pub use resume::{check_resume_state, ResumeDecision};
 pub use transfer::{
@@ -50,6 +51,16 @@ impl RemotePath {
             host: self.host.clone(),
             path,
         }
+    }
+
+    pub async fn expand_tilde(&mut self) -> Result<(), crate::core::error::BcmrError> {
+        if !self.path.starts_with('~') {
+            return Ok(());
+        }
+        let target = self.ssh_target();
+        let expanded = ops::expand_remote_tilde(&target, &self.path).await?;
+        self.path = expanded;
+        Ok(())
     }
 
     pub fn reject_unsafe(&self) -> Result<(), crate::core::error::BcmrError> {

--- a/src/core/remote/ops.rs
+++ b/src/core/remote/ops.rs
@@ -177,6 +177,59 @@ pub async fn remote_file_hash(
     Ok(hasher.finalize().to_hex().to_string())
 }
 
+fn split_tilde_prefix(path: &str) -> Option<(&str, &str)> {
+    let after_tilde = path.strip_prefix('~')?;
+    let (user_spec, suffix) = match after_tilde.find('/') {
+        Some(idx) => (&after_tilde[..idx], &after_tilde[idx..]),
+        None => (after_tilde, ""),
+    };
+    Some((user_spec, suffix))
+}
+
+pub async fn resolve_remote_home(ssh_target: &str, user_spec: &str) -> Result<String, BcmrError> {
+    let probe = if user_spec.is_empty() {
+        "printf '%s' \"$HOME\"".to_string()
+    } else {
+        if !user_spec
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            return Err(BcmrError::InvalidInput(format!(
+                "remote path: refusing to expand ~{} — only alphanumeric/_/- usernames accepted",
+                user_spec
+            )));
+        }
+        format!("printf '%s' ~{}", user_spec)
+    };
+
+    let output = ssh_command(ssh_target).arg(&probe).output().await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(BcmrError::InvalidInput(ssh_error_message(
+            &stderr,
+            &format!("remote ~{} expansion", user_spec),
+        )));
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let home = raw.trim().to_string();
+    if home.is_empty() || home.starts_with('~') {
+        return Err(BcmrError::InvalidInput(format!(
+            "remote did not expand ~{} (no such user, or HOME unset)",
+            user_spec
+        )));
+    }
+    Ok(home)
+}
+
+pub async fn expand_remote_tilde(ssh_target: &str, path: &str) -> Result<String, BcmrError> {
+    let Some((user_spec, suffix)) = split_tilde_prefix(path) else {
+        return Ok(path.to_string());
+    };
+    let home = resolve_remote_home(ssh_target, user_spec).await?;
+    Ok(format!("{}{}", home, suffix))
+}
+
 pub async fn remote_remove(
     remote: &RemotePath,
     recursive: bool,
@@ -244,4 +297,31 @@ pub async fn complete_remote_path(partial: &str) -> Vec<String> {
         .filter(|l| prefix.is_empty() || l.starts_with(&prefix))
         .map(|l| format!("{}:{}{}", target, base, l))
         .collect()
+}
+
+#[cfg(test)]
+mod tilde_tests {
+    use super::split_tilde_prefix;
+
+    #[test]
+    fn split_handles_bare_tilde() {
+        assert_eq!(split_tilde_prefix("~"), Some(("", "")));
+        assert_eq!(split_tilde_prefix("~/"), Some(("", "/")));
+        assert_eq!(split_tilde_prefix("~/foo"), Some(("", "/foo")));
+        assert_eq!(split_tilde_prefix("~/foo/bar"), Some(("", "/foo/bar")));
+    }
+
+    #[test]
+    fn split_handles_user_tilde() {
+        assert_eq!(split_tilde_prefix("~alice"), Some(("alice", "")));
+        assert_eq!(split_tilde_prefix("~alice/foo"), Some(("alice", "/foo")));
+    }
+
+    #[test]
+    fn split_returns_none_for_non_tilde() {
+        assert_eq!(split_tilde_prefix(""), None);
+        assert_eq!(split_tilde_prefix("foo"), None);
+        assert_eq!(split_tilde_prefix("/abs/path"), None);
+        assert_eq!(split_tilde_prefix("./foo~"), None);
+    }
 }


### PR DESCRIPTION
## Summary
The fast path bypasses the remote shell, so `~` segments arrived at the serve daemon as literal directory names — files landed under a literal `~` directory inside `\$HOME` (`/home/user/~/foo`), and the deploy default `--path ~/.local/bin/bcmr` did the same to its `mkdir` + sftp put. The legacy fallback wasn't safer either: every command goes through single-quoted shell args, so the shell's own tilde expansion is suppressed.

Add `resolve_remote_home` + `expand_remote_tilde` (`core/remote/ops.rs`) that probe the remote's `\$HOME` (or `~user` via a constrained `printf` form — only alphanumeric / `_-` usernames are accepted, no shell injection vector) and substitute. `RemotePath::expand_tilde` wires it onto the type. Call sites:

- `handle_remote_copy` — every remote source and the remote dest.
- `handle_remove_command`'s remote bucket.
- `commands::check::run`.
- `commands::deploy::run` — closes #39 in passing.

## Verified on 4090_j

```
$ bcmr copy /tmp/tt.txt '4090_j:~/tilde_test.txt'
Done: 11 B in 0.0s | avg 243 B/s
$ ssh 4090_j 'ls -la ~/tilde_test.txt; ls -la "$HOME/~"'
-rw-rw-r-- 1 liangjy liangjy 11 May 10 00:51 /home/liangjy/tilde_test.txt
ls: cannot access '/home/liangjy/~': No such file or directory   ← no literal ~ dir
```

Same for `~liangjy/tt2.txt` (push), `host:~/path` (pull), and `bcmr deploy 4090_j` (default `--path ~/.local/bin/bcmr` now lands at `/home/liangjy/.local/bin/bcmr`).

## Safety
`~user` resolution rejects any user name containing characters outside `[A-Za-z0-9_-]` so the probe (`printf '%s' ~user`) can't be turned into a shell-injection vector. For users whose names contain other characters, the operation errors with a clear message rather than silently expanding to something arbitrary.

## Test plan
- [x] 3 new unit tests for `split_tilde_prefix` (bare, user, non-tilde).
- [x] `cargo test --lib` 82 passed.
- [x] Push `~/path`, push `~user/path`, pull `host:~/path`, deploy default — all on 4090_j.

Closes #61
Closes #39