### PR TITLE
fix: probe non-interactive PATH after deploy + warn on mismatch (#41)

### DIFF
--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -87,6 +87,43 @@ pub async fn run(target: &str, remote_path: &str) -> Result<()> {
     ssh(target, &format!("chmod +x {}", shell_escape(remote_path))).await?;
     let verify = ssh(target, &format!("{} --version", shell_escape(remote_path))).await?;
     eprintln!("  Installed: {}", verify.trim());
+
+    let path_probe = ssh(target, "command -v bcmr 2>/dev/null || true").await?;
+    let resolved = path_probe.trim();
+    if resolved.is_empty() {
+        eprintln!();
+        eprintln!("  ⚠  bcmr is installed but NOT on the remote's non-interactive SSH PATH.");
+        eprintln!(
+            "     Subsequent bcmr operations against {} will fall back to legacy SSH",
+            target
+        );
+        eprintln!("     until the install directory is added to PATH.");
+        eprintln!();
+        let install_dir = if remote_path.contains('/') {
+            remote_path.rsplit_once('/').map(|(d, _)| d).unwrap_or(".")
+        } else {
+            "."
+        };
+        eprintln!("     Quick fix on the remote (one of these):");
+        eprintln!(
+            "       echo 'export PATH={}:$PATH' >> ~/.profile   # picked up by future SSH",
+            install_dir
+        );
+        eprintln!(
+            "       sudo ln -s {} /usr/local/bin/bcmr            # system-wide",
+            remote_path
+        );
+    } else if resolved != remote_path {
+        eprintln!();
+        eprintln!(
+            "  ⚠  Deployed to {} but 'command -v bcmr' resolves to {}",
+            remote_path, resolved
+        );
+        eprintln!(
+            "     (the PATH-resolved binary will be used by bcmr operations against {}).",
+            target
+        );
+    }
     eprintln!("  Done.");
 
     Ok(())


### PR DESCRIPTION
## Summary
After `bcmr deploy --path ~/.local/bin/bcmr <host>`, every subsequent bcmr operation against that host fell back to legacy SSH with no signal — the deploy looked successful but was effectively a no-op for fast-path purposes on Ubuntu (`~/.bashrc` returns early for non-interactive shells, `~/.profile` isn't sourced).

Run `command -v bcmr` over the same `BatchMode=yes` SSH the serve probe will use, then surface:
- empty result → loud warning naming the install dir, with two concrete fixes (`echo 'export PATH=…' >> ~/.profile` user-level, or `sudo ln -s … /usr/local/bin/bcmr` system-wide).
- non-empty but different from the deployed path → warn that PATH resolves to a different binary, naming both paths so the user can pick.
- match → silent (current `Done.` behaviour).

Did **not** take the issue's option (1) — caching the absolute path and rewriting all subsequent serve invocations. That's a much bigger architectural change (per-host config, threading the path through every `ssh host 'bcmr serve …'` site) and the post-install probe + actionable warning resolves the actual user complaint ("I had no idea") with maybe 1% the LoC.

## Verified end-to-end

**Empty-probe (lunemira_sv, Ubuntu 22.04, fresh, no bcmr in non-interactive PATH):**
```
$ bcmr deploy lunemira_sv
…
  ⚠  bcmr is installed but NOT on the remote's non-interactive SSH PATH.
     Subsequent bcmr operations against lunemira_sv will fall back to legacy SSH
     until the install directory is added to PATH.
     Quick fix on the remote (one of these):
       echo 'export PATH=~/.local/bin:$PATH' >> ~/.profile   # picked up by future SSH
       sudo ln -s ~/.local/bin/bcmr /usr/local/bin/bcmr            # system-wide
```

**Mismatch (4090_j, Linux: `~/.cargo/bin/bcmr` is in PATH, deploy goes to `~/.local/bin/bcmr`):**
```
$ bcmr deploy 4090_j
…
  ⚠  Deployed to ~/.local/bin/bcmr but 'command -v bcmr' resolves to /home/liangjy/.cargo/bin/bcmr
     (the PATH-resolved binary will be used by bcmr operations against 4090_j).
```

## Test plan
- [x] `cargo test --lib` 79 passed.
- [x] Empty-probe warning verified end-to-end on lunemira_sv.
- [x] Mismatch warning verified end-to-end on 4090_j (PATH has `.cargo/bin/bcmr` first; deploy lands at `~/.local/bin/bcmr`).

Closes #41