### PR TITLE
feat: add --sudo to bcmr deploy for system-wide install (#40)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -222,6 +222,10 @@ pub enum Commands {
         /// Installation path on remote host
         #[arg(long, default_value = "~/.local/bin/bcmr")]
         path: Option<String>,
+
+        /// Use sudo on the remote for the install step (requires passwordless sudo)
+        #[arg(long)]
+        sudo: bool,
     },
 
     /// Compare source and destination without making changes

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use tokio::process::Command;
 
-pub async fn run(target: &str, remote_path: &str) -> Result<()> {
+pub async fn run(target: &str, remote_path: &str, sudo: bool) -> Result<()> {
     let remote_path_owned = if remote_path.starts_with('~') {
         crate::core::remote::expand_remote_tilde(target, remote_path).await?
     } else {
@@ -9,6 +9,30 @@ pub async fn run(target: &str, remote_path: &str) -> Result<()> {
     };
     let remote_path = remote_path_owned.as_str();
     eprintln!("Deploying bcmr to {}:{}", target, remote_path);
+
+    if sudo {
+        let probe = Command::new("ssh")
+            .args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"])
+            .arg(target)
+            .arg("sudo -n true")
+            .output()
+            .await?;
+        if !probe.status.success() {
+            let stderr = String::from_utf8_lossy(&probe.stderr);
+            let reason = stderr.trim();
+            let suffix = if reason.is_empty() {
+                String::new()
+            } else {
+                format!(": {}", reason)
+            };
+            bail!(
+                "--sudo requires passwordless sudo on {} (`sudo -n true` failed{})",
+                target,
+                suffix
+            );
+        }
+        eprintln!("  Verified passwordless sudo on remote.");
+    }
 
     let check = ssh(target, "bcmr --version 2>/dev/null || echo NOTFOUND").await?;
     if !check.contains("NOTFOUND") {
@@ -30,66 +54,108 @@ pub async fn run(target: &str, remote_path: &str) -> Result<()> {
     let local_arch = std::env::consts::ARCH;
     eprintln!("  Local:  {} {}", local_os, local_arch);
 
+    let sudo_prefix = if sudo { "sudo " } else { "" };
     let dir = if remote_path.contains('/') {
         remote_path.rsplit_once('/').map(|(d, _)| d).unwrap_or(".")
     } else {
         "."
     };
-    ssh(target, &format!("mkdir -p {}", shell_escape(dir))).await?;
+    ssh(
+        target,
+        &format!("{}mkdir -p {}", sudo_prefix, shell_escape(dir)),
+    )
+    .await?;
 
-    if remote_os == local_os && remote_arch == local_arch {
-        eprintln!("  Same platform. Transferring local binary...");
-        let local_bin = std::env::current_exe()?;
-        scp_to(target, &local_bin, remote_path).await?;
+    let staging = if sudo {
+        let raw = ssh(target, "mktemp -t bcmr-deploy.XXXXXX").await?;
+        let path = raw.trim().to_string();
+        if path.is_empty() {
+            bail!("--sudo: failed to allocate a remote staging path via mktemp");
+        }
+        Some(path)
     } else {
-        eprintln!("  Cross-platform. Downloading from GitHub Releases...");
-        let asset_name = release_asset_name(remote_os, remote_arch)?;
-        let url = format!(
-            "https://github.com/Bengerthelorf/bcmr/releases/latest/download/{}",
-            asset_name
-        );
-        let download_cmd = format!(
-            "curl -fsSL '{}' | tar xz -C {} bcmr && mv {}/bcmr {}",
-            url,
-            shell_escape(dir),
-            shell_escape(dir),
-            shell_escape(remote_path)
-        );
-        let output = ssh(target, &download_cmd).await;
-        if output.is_err() {
-            eprintln!("  Direct download failed. Downloading locally...");
-            let tmp_dir = std::env::temp_dir().join("bcmr-deploy-tmp");
-            let _ = tokio::fs::create_dir_all(&tmp_dir).await;
-            let tmp_archive = tmp_dir.join(&asset_name);
-            let status = Command::new("curl")
-                .args(["-fsSL", &url, "-o"])
-                .arg(&tmp_archive)
-                .status()
-                .await?;
-            if !status.success() {
-                bail!(
-                    "Failed to download {} from GitHub Releases.\n\
-                     Install manually: cargo install bcmr",
-                    asset_name
-                );
+        None
+    };
+    let upload_dest = staging.as_deref().unwrap_or(remote_path);
+
+    let install_outcome: Result<()> = async {
+        if remote_os == local_os && remote_arch == local_arch {
+            eprintln!("  Same platform. Transferring local binary...");
+            let local_bin = std::env::current_exe()?;
+            scp_to(target, &local_bin, upload_dest).await?;
+        } else {
+            eprintln!("  Cross-platform. Downloading from GitHub Releases...");
+            let asset_name = release_asset_name(remote_os, remote_arch)?;
+            let url = format!(
+                "https://github.com/Bengerthelorf/bcmr/releases/latest/download/{}",
+                asset_name
+            );
+            let extract_dir = format!("/tmp/bcmr-deploy-extract-{}", std::process::id());
+            let download_cmd = format!(
+                "rm -rf {0} && mkdir -p {0} && curl -fsSL '{1}' | tar xz -C {0} bcmr && mv {0}/bcmr {2} && rm -rf {0}",
+                shell_escape(&extract_dir),
+                url,
+                shell_escape(upload_dest)
+            );
+            let output = ssh(target, &download_cmd).await;
+            if output.is_err() {
+                eprintln!("  Direct download failed. Downloading locally...");
+                let tmp_dir = std::env::temp_dir().join("bcmr-deploy-tmp");
+                let _ = tokio::fs::create_dir_all(&tmp_dir).await;
+                let tmp_archive = tmp_dir.join(&asset_name);
+                let status = Command::new("curl")
+                    .args(["-fsSL", &url, "-o"])
+                    .arg(&tmp_archive)
+                    .status()
+                    .await?;
+                if !status.success() {
+                    bail!(
+                        "Failed to download {} from GitHub Releases.\n\
+                         Install manually: cargo install bcmr",
+                        asset_name
+                    );
+                }
+                let status = Command::new("tar")
+                    .args(["xzf"])
+                    .arg(&tmp_archive)
+                    .args(["-C"])
+                    .arg(&tmp_dir)
+                    .status()
+                    .await?;
+                if !status.success() {
+                    bail!("Failed to extract {}", asset_name);
+                }
+                let extracted = tmp_dir.join("bcmr");
+                scp_to(target, &extracted, upload_dest).await?;
+                let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
             }
-            let status = Command::new("tar")
-                .args(["xzf"])
-                .arg(&tmp_archive)
-                .args(["-C"])
-                .arg(&tmp_dir)
-                .status()
-                .await?;
-            if !status.success() {
-                bail!("Failed to extract {}", asset_name);
-            }
-            let extracted = tmp_dir.join("bcmr");
-            scp_to(target, &extracted, remote_path).await?;
-            let _ = tokio::fs::remove_dir_all(&tmp_dir).await;
+        }
+
+        if let Some(ref staged) = staging {
+            ssh(
+                target,
+                &format!(
+                    "{}install -m 755 {} {} && rm -f {}",
+                    sudo_prefix,
+                    shell_escape(staged),
+                    shell_escape(remote_path),
+                    shell_escape(staged)
+                ),
+            )
+            .await?;
+        } else {
+            ssh(target, &format!("chmod +x {}", shell_escape(remote_path))).await?;
+        }
+        Ok(())
+    }
+    .await;
+
+    if install_outcome.is_err() {
+        if let Some(staged) = staging.as_deref() {
+            let _ = ssh(target, &format!("rm -f {}", shell_escape(staged))).await;
         }
     }
-
-    ssh(target, &format!("chmod +x {}", shell_escape(remote_path))).await?;
+    install_outcome?;
     let verify = ssh(target, &format!("{} --version", shell_escape(remote_path))).await?;
     eprintln!("  Installed: {}", verify.trim());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,9 +133,9 @@ async fn main() -> Result<()> {
                 commands::serve::run(root.clone()).await?;
             }
         }
-        Commands::Deploy { target, path } => {
+        Commands::Deploy { target, path, sudo } => {
             let remote_path = path.as_deref().unwrap_or("~/.local/bin/bcmr");
-            commands::deploy::run(target, remote_path).await?;
+            commands::deploy::run(target, remote_path, *sudo).await?;
         }
         Commands::CompleteRemote { partial } => {
             for entry in crate::core::remote::complete_remote_path(partial).await {


### PR DESCRIPTION
## Summary
`bcmr deploy --path /usr/local/bin/bcmr <target>` failed with `Permission denied` even when the user had passwordless sudo. Add `--sudo`:

- `sudo -n true` upfront to fail fast (with a useful message) if passwordless sudo isn't actually available.
- Prepend `sudo` to the remote `mkdir` / `mv` / `chmod` calls.
- Stage the binary to `/tmp/bcmr-deploy-<pid>.bin` first — the SFTP put runs as the SSH user and can't write to `/usr/local/bin` directly. Both the same-platform sftp path and the cross-platform `curl`-on-remote / `curl`-locally-then-sftp paths land at the same staging spot, so the `sudo mv` step is uniform regardless of which install pipeline ran.

## Verified

**Positive (lunemira_sv, Ubuntu 22.04, passwordless sudo):**
```
$ bcmr deploy --path /usr/local/bin/bcmr lunemira_sv
… dest open "/usr/local/bin/bcmr": Permission denied        # without --sudo

$ bcmr deploy --sudo --path /usr/local/bin/bcmr lunemira_sv
…
  Verified passwordless sudo on remote.
  Installed: bcmr 0.6.0
  Done.
$ ssh lunemira_sv 'ls -la /usr/local/bin/bcmr; bcmr --version'
-rwxr-xr-x 1 ubuntu ubuntu 9893776 … /usr/local/bin/bcmr
bcmr 0.6.0
```

**Negative (mini_m2, sudo requires password):**
```
$ bcmr deploy --sudo --path /usr/local/bin/bcmr mini_m2
Deploying bcmr to mini_m2:/usr/local/bin/bcmr
Error: --sudo requires passwordless sudo on mini_m2. `sudo -n true` failed:
$ echo $?
1
```
Probe runs upfront, bails before any install side-effect.

## Test plan
- [x] `cargo test --lib` 79 passed.
- [x] Without `--sudo` to a non-writable `/usr/local/bin`: existing failure preserved.
- [x] With `--sudo`: passwordless probe verified, install lands at `/usr/local/bin/bcmr`, runs cleanly.
- [x] Negative-path: `--sudo` against mini_m2 (sudo requires password) → `sudo -n true` non-zero, bails upfront with the explanation message, exit 1.

Closes #40