### PR TITLE
fix: copy to existing remote dir without trailing slash (#54)

### DIFF
--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -263,7 +263,22 @@ pub async fn handle_remote_copy(
         }
     }
     let sources: &[PathBuf] = &expanded_sources;
-    let dest: &std::path::Path = expanded_dest_buf.as_path();
+
+    let expanded_dest_str = expanded_dest_buf.to_string_lossy();
+    let expanded_remote_dest = parse_remote_path(&expanded_dest_str);
+    let dest_buf: PathBuf = if let Some(ref rd) = expanded_remote_dest {
+        let needs_dir_probe = !rd.path.ends_with('/') && rd.path != "." && !rd.path.is_empty();
+        if needs_dir_probe && remote::remote_path_is_directory(rd).await {
+            let mut probed = rd.clone();
+            probed.path.push('/');
+            PathBuf::from(probed.display())
+        } else {
+            expanded_dest_buf.clone()
+        }
+    } else {
+        expanded_dest_buf.clone()
+    };
+    let dest: &std::path::Path = dest_buf.as_path();
     let dest_str = dest.to_string_lossy();
     let remote_dest = parse_remote_path(&dest_str);
 

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -9,8 +9,8 @@ pub use attrs::{apply_remote_attrs_locally, preserve_remote_attrs, verify_remote
 #[allow(unused_imports)]
 pub use ops::{
     complete_remote_path, expand_remote_tilde, remote_file_hash, remote_file_size,
-    remote_list_files, remote_remove, remote_stat, remote_total_size, resolve_remote_home,
-    validate_ssh_connection,
+    remote_list_files, remote_path_is_directory, remote_remove, remote_stat, remote_total_size,
+    resolve_remote_home, validate_ssh_connection,
 };
 pub use resume::{check_resume_state, ResumeDecision};
 pub use transfer::{

--- a/src/core/remote/ops.rs
+++ b/src/core/remote/ops.rs
@@ -230,6 +230,17 @@ pub async fn expand_remote_tilde(ssh_target: &str, path: &str) -> Result<String,
     Ok(format!("{}{}", home, suffix))
 }
 
+pub async fn remote_path_is_directory(remote: &RemotePath) -> bool {
+    let cmd = format!("test -d '{}'", shell_escape(&remote.path));
+    let status = ssh_command(&remote.ssh_target())
+        .arg(&cmd)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await;
+    matches!(status, Ok(s) if s.success())
+}
+
 pub async fn remote_remove(
     remote: &RemotePath,
     recursive: bool,


### PR DESCRIPTION
## Summary
`bcmr copy file host:existing_dir` failed with `Is a directory (os error 21)` on the fast path and `is a directory: dir` via legacy. Both code paths assumed `host:dir` was a target file. Pre-stat the dest at `handle_remote_copy` entry; if it's a directory and the user didn't already signal that with a trailing slash or `.`, append `/` so the existing trailing-slash → join-basename code fires uniformly.

## Why `test -d` instead of the existing `remote_stat`
Hit a real fail during testing on 4090_j (Chinese locale). `remote_stat` parses `stat -c '%F'` output and matches `starts_with("directory")` — the locale returned `"目录"` and the probe silently said "not a directory", reproducing the same bug. Switched to `test -d` (locale-independent exit-code probe) for this gate. The new helper `remote_path_is_directory` lives in `core/remote/ops.rs`.

## Verified on 4090_j
| input | dest | result |
|---|---|---|
| `host:r54/d` (existing dir) | `r54/d/file54.txt` | ✓ |
| `host:r54/newfile` (doesn't exist) | `r54/newfile` (regular file) | ✓ |
| `host:r54/d/` (regression — trailing slash) | `r54/d/file54.txt` | ✓ |

## Test plan
- [x] `cargo test --lib` 79 passed.
- [x] All three cases above end-to-end on 4090_j.
- [x] Locale check: 4090_j is Chinese; the new `test -d` probe works correctly there.

Closes #54