### PR TITLE
fix: refuse FIFO / socket / device-node sources in copy and move (#59)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -12,6 +12,51 @@ use crate::ui::utils::format_bytes;
 use anyhow::{bail, Result};
 use std::sync::Arc;
 
+#[cfg(unix)]
+fn validate_source_kind(src: &std::path::Path) -> Result<()> {
+    use crate::core::remote::parse_remote_path;
+    use std::os::unix::fs::FileTypeExt;
+
+    if parse_remote_path(&src.to_string_lossy()).is_some() {
+        return Ok(());
+    }
+    let md = match src.metadata() {
+        Ok(m) => m,
+        Err(_) => return Ok(()),
+    };
+    let ft = md.file_type();
+    if ft.is_file() || ft.is_dir() {
+        return Ok(());
+    }
+    let kind = if ft.is_fifo() {
+        "FIFO (named pipe)"
+    } else if ft.is_socket() {
+        "socket"
+    } else if ft.is_block_device() {
+        "block device"
+    } else if ft.is_char_device() {
+        "character device"
+    } else {
+        "non-regular file"
+    };
+    let hint = if src.to_str() == Some("/dev/null") {
+        "\nTo clear a remote file, use: : > /tmp/empty && bcmr copy /tmp/empty <dest>"
+    } else {
+        ""
+    };
+    bail!(
+        "Source '{}' is a {}; bcmr copy supports only regular files and directories.{}",
+        src.display(),
+        kind,
+        hint
+    );
+}
+
+#[cfg(not(unix))]
+fn validate_source_kind(_src: &std::path::Path) -> Result<()> {
+    Ok(())
+}
+
 pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
     use crate::core::remote::parse_remote_path;
 
@@ -23,6 +68,10 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
     }
     if let Some(mode) = args.get_sparse_mode() {
         validate_mode(&mode, "sparse")?;
+    }
+
+    for src in sources {
+        validate_source_kind(src)?;
     }
 
     let dest_str = dest.to_string_lossy();
@@ -182,6 +231,10 @@ pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
 
     let excludes = args.compile_excludes()?;
     let (sources, dest) = args.get_sources_and_dest().map_err(anyhow::Error::msg)?;
+
+    for src in sources {
+        validate_source_kind(src)?;
+    }
 
     let dest_str = dest.to_string_lossy();
     let remote_dest = parse_remote_path(&dest_str);


### PR DESCRIPTION
## Summary
\`bcmr copy /dev/null host:dst.txt\` and \`bcmr copy fifo host:dst.txt\` both exited 0 with \`Done: 0 B\` and didn't create the remote file — \`serve_upload\`'s loop accepted only \`is_file()\` sources and silently skipped non-regular paths. Same systemic shape as #35 / #52 / #58.

Add \`validate_source_kind\` that refuses FIFO / socket / block device / character device sources at \`handle_copy_command\` and \`handle_move_command\` entry. The error names the kind, and for \`/dev/null\` specifically suggests the explicit clear-the-file idiom (\`: > /tmp/empty && bcmr copy /tmp/empty <dest>\`).

## Picked option (1) over option (2)
Reporter listed three: refuse, replicate cp (create empty for /dev/null), or stream-through FIFO. Refusing keeps the implementation narrow (no special-cased zero-size pipeline through the serve protocol), and the \`/dev/null\` hint covers the canonical use case the issue called out — clearing a remote log file. Stream-through-FIFO would conflict with bcmr's hashing / resume design which assumes seekable sources.

## Verified on 4090_j

```
$ bcmr copy /dev/null 4090_j:r59/null.txt
Error: Source '/dev/null' is a character device; bcmr copy supports only regular files and directories.
To clear a remote file, use: : > /tmp/empty && bcmr copy /tmp/empty <dest>

$ bcmr copy /tmp/test59.fifo 4090_j:r59/fifo.txt
Error: Source '/tmp/test59.fifo' is a FIFO (named pipe); bcmr copy supports only regular files and directories.

$ bcmr copy /tmp/regular.txt 4090_j:r59/x.txt
Done: 3 B in 0.1s | avg 22 B/s   ← regression check, works as before
```

Implementation is Unix-only (file-type extensions); Windows path is a no-op.

Closes #59