### PR TITLE
fix: confirm same-size mtime-only diffs by hash before reporting modified (#42)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -516,7 +516,8 @@ pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {
 pub(crate) async fn handle_check_command(args: &Commands) -> Result<output::CheckResult> {
     let excludes = args.compile_excludes()?;
     let (sources, dest) = args.get_sources_and_dest().map_err(anyhow::Error::msg)?;
-    Ok(commands::check::run(sources, dest, args.is_recursive(), &excludes).await?)
+    let no_hash = matches!(args, Commands::Check { no_hash: true, .. });
+    Ok(commands::check::run(sources, dest, args.is_recursive(), &excludes, no_hash).await?)
 }
 
 pub(crate) fn handle_init_command(args: &Commands) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,10 @@ pub enum Commands {
         /// Exclude paths matching regex pattern
         #[arg(short = 'e', long)]
         exclude: Option<Vec<String>>,
+
+        /// Skip content hashing — flag size-matched, mtime-drifted files as modified
+        #[arg(long = "no-hash")]
+        no_hash: bool,
     },
 
     /// Remove files or directories

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -15,8 +15,16 @@ struct Entry {
 }
 
 enum SideRoot {
-    Local(PathBuf),
-    Remote(RemotePath),
+    LocalDir(PathBuf),
+    LocalFile(PathBuf),
+    RemoteDir(RemotePath),
+    RemoteFile(RemotePath),
+}
+
+impl SideRoot {
+    fn is_file(&self) -> bool {
+        matches!(self, SideRoot::LocalFile(_) | SideRoot::RemoteFile(_))
+    }
 }
 
 struct CollectResult {
@@ -31,6 +39,7 @@ pub async fn run(
     dest: &Path,
     recursive: bool,
     excludes: &[regex::Regex],
+    no_hash: bool,
 ) -> Result<CheckResult, BcmrError> {
     let dest_str = dest.to_string_lossy();
     let remote_dest = parse_remote_path(&dest_str);
@@ -92,14 +101,29 @@ pub async fn run(
         )
         .await?;
 
-        let (added, modified, missing) = diff_entries(collected.src_entries, collected.dst_entries);
-        let modified = filter_size_match_via_hash(
-            modified,
-            &collected.src_root,
-            &collected.dst_root,
-            &mut serve_client,
-        )
-        .await?;
+        let both_file_roots = collected.src_root.is_file() && collected.dst_root.is_file();
+        let (added, mut modified, missing) =
+            diff_entries(&collected.src_entries, &collected.dst_entries);
+        // diff_entries trusts size+mtime; for explicit file-to-file we always
+        // confirm with a hash since the user named these two files specifically.
+        if both_file_roots && !no_hash && modified.is_empty() {
+            if let (Some(s), Some(d)) =
+                (collected.src_entries.first(), collected.dst_entries.first())
+            {
+                modified.push(modified_diff(s, d));
+            }
+        }
+        let modified = if no_hash {
+            modified
+        } else {
+            filter_size_match_via_hash(
+                modified,
+                &collected.src_root,
+                &collected.dst_root,
+                &mut serve_client,
+            )
+            .await?
+        };
         all_added.extend(added);
         all_modified.extend(modified);
         all_missing.extend(missing);
@@ -236,20 +260,11 @@ async fn collect_both(
         }
     };
 
-    let src_root = if let Some(ref rp) = remote_src {
-        if src_is_dir {
-            SideRoot::Remote(rp.clone())
-        } else {
-            SideRoot::Remote(remote_parent(rp))
-        }
-    } else if src_is_dir {
-        SideRoot::Local(src.to_path_buf())
-    } else {
-        SideRoot::Local(
-            src.parent()
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|| PathBuf::from(".")),
-        )
+    let src_root = match (&remote_src, src_is_dir) {
+        (Some(rp), true) => SideRoot::RemoteDir(rp.clone()),
+        (Some(rp), false) => SideRoot::RemoteFile(rp.clone()),
+        (None, true) => SideRoot::LocalDir(src.to_path_buf()),
+        (None, false) => SideRoot::LocalFile(src.to_path_buf()),
     };
 
     let dst_root = if is_remote_dest {
@@ -257,25 +272,19 @@ async fn collect_both(
             BcmrError::InvalidInput(format!("Invalid remote path: {}", dest.display()))
         })?;
         let rdest_is_dir = remote_is_dir(&rdest, serve).await.unwrap_or(false);
-        if rdest_is_dir {
-            SideRoot::Remote(rdest.join(&src_name))
-        } else if src_is_dir {
-            SideRoot::Remote(rdest)
-        } else {
-            SideRoot::Remote(remote_parent(&rdest))
+        match (rdest_is_dir, src_is_dir) {
+            (true, true) => SideRoot::RemoteDir(rdest.join(&src_name)),
+            (true, false) => SideRoot::RemoteFile(rdest.join(&src_name)),
+            (false, true) => SideRoot::RemoteDir(rdest),
+            (false, false) => SideRoot::RemoteFile(rdest),
         }
     } else {
         let dest_is_dir = dest.exists() && dest.is_dir();
-        if dest_is_dir {
-            SideRoot::Local(dest.join(&src_name))
-        } else if src_is_dir {
-            SideRoot::Local(dest.to_path_buf())
-        } else {
-            SideRoot::Local(
-                dest.parent()
-                    .map(|p| p.to_path_buf())
-                    .unwrap_or_else(|| PathBuf::from(".")),
-            )
+        match (dest_is_dir, src_is_dir) {
+            (true, true) => SideRoot::LocalDir(dest.join(&src_name)),
+            (true, false) => SideRoot::LocalFile(dest.join(&src_name)),
+            (false, true) => SideRoot::LocalDir(dest.to_path_buf()),
+            (false, false) => SideRoot::LocalFile(dest.to_path_buf()),
         }
     };
 
@@ -285,19 +294,6 @@ async fn collect_both(
         src_root,
         dst_root,
     })
-}
-
-fn remote_parent(rp: &RemotePath) -> RemotePath {
-    let parent_path = match rp.path.rsplit_once('/') {
-        Some((p, _)) if !p.is_empty() => p.to_string(),
-        Some(_) => "/".to_string(),
-        None => ".".to_string(),
-    };
-    RemotePath {
-        user: rp.user.clone(),
-        host: rp.host.clone(),
-        path: parent_path,
-    }
 }
 
 async fn remote_is_dir(
@@ -423,22 +419,29 @@ async fn hash_at(
     serve: &mut Option<ServeClient>,
 ) -> Result<String, BcmrError> {
     match root {
-        SideRoot::Local(base) => {
-            let abs = base.join(rel);
-            tokio::task::spawn_blocking(move || crate::core::checksum::calculate_hash(&abs))
-                .await
-                .map_err(|e| BcmrError::InvalidInput(e.to_string()))?
-                .map_err(BcmrError::Io)
-        }
-        SideRoot::Remote(base) => {
-            let target = base.join(&rel.to_string_lossy());
-            if let Some(client) = serve.as_mut() {
-                let bytes = client.hash(&target.path, 0, None).await?;
-                return Ok(bytes.iter().map(|b| format!("{:02x}", b)).collect());
-            }
-            remote::remote_file_hash(&target, None).await
-        }
+        SideRoot::LocalDir(base) => hash_local(base.join(rel)).await,
+        SideRoot::LocalFile(path) => hash_local(path.clone()).await,
+        SideRoot::RemoteDir(base) => hash_remote(base.join(&rel.to_string_lossy()), serve).await,
+        SideRoot::RemoteFile(rp) => hash_remote(rp.clone(), serve).await,
     }
+}
+
+async fn hash_local(abs: PathBuf) -> Result<String, BcmrError> {
+    tokio::task::spawn_blocking(move || crate::core::checksum::calculate_hash(&abs))
+        .await
+        .map_err(|e| BcmrError::InvalidInput(e.to_string()))?
+        .map_err(BcmrError::Io)
+}
+
+async fn hash_remote(
+    target: RemotePath,
+    serve: &mut Option<ServeClient>,
+) -> Result<String, BcmrError> {
+    if let Some(client) = serve.as_mut() {
+        let bytes = client.hash(&target.path, 0, None).await?;
+        return Ok(bytes.iter().map(|b| format!("{:02x}", b)).collect());
+    }
+    remote::remote_file_hash(&target, None).await
 }
 
 async fn filter_size_match_via_hash(
@@ -468,7 +471,17 @@ async fn filter_size_match_via_hash(
     Ok(kept)
 }
 
-fn diff_entries(src: Vec<Entry>, dst: Vec<Entry>) -> (Vec<FileDiff>, Vec<FileDiff>, Vec<FileDiff>) {
+fn modified_diff(s: &Entry, d: &Entry) -> FileDiff {
+    FileDiff {
+        path: PathBuf::from(&s.rel_path),
+        size: None,
+        src_size: Some(s.size),
+        dst_size: Some(d.size),
+        is_dir: false,
+    }
+}
+
+fn diff_entries(src: &[Entry], dst: &[Entry]) -> (Vec<FileDiff>, Vec<FileDiff>, Vec<FileDiff>) {
     let dst_map: HashMap<&str, &Entry> = dst.iter().map(|e| (e.rel_path.as_str(), e)).collect();
     let src_map: HashMap<&str, &Entry> = src.iter().map(|e| (e.rel_path.as_str(), e)).collect();
 
@@ -476,7 +489,7 @@ fn diff_entries(src: Vec<Entry>, dst: Vec<Entry>) -> (Vec<FileDiff>, Vec<FileDif
     let mut modified = Vec::new();
     let mut missing = Vec::new();
 
-    for s in &src {
+    for s in src {
         match dst_map.get(s.rel_path.as_str()) {
             None => {
                 added.push(FileDiff {
@@ -492,19 +505,13 @@ fn diff_entries(src: Vec<Entry>, dst: Vec<Entry>) -> (Vec<FileDiff>, Vec<FileDif
                     && (s.size != d.size
                         || (s.mtime != 0 && d.mtime != 0 && s.mtime != d.mtime)) =>
             {
-                modified.push(FileDiff {
-                    path: PathBuf::from(&s.rel_path),
-                    size: None,
-                    src_size: Some(s.size),
-                    dst_size: Some(d.size),
-                    is_dir: false,
-                });
+                modified.push(modified_diff(s, d));
             }
             _ => {}
         }
     }
 
-    for d in &dst {
+    for d in dst {
         if !src_map.contains_key(d.rel_path.as_str()) {
             missing.push(FileDiff {
                 path: PathBuf::from(&d.rel_path),

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -14,6 +14,18 @@ struct Entry {
     is_dir: bool,
 }
 
+enum SideRoot {
+    Local(PathBuf),
+    Remote(RemotePath),
+}
+
+struct CollectResult {
+    src_entries: Vec<Entry>,
+    dst_entries: Vec<Entry>,
+    src_root: SideRoot,
+    dst_root: SideRoot,
+}
+
 pub async fn run(
     sources: &[PathBuf],
     dest: &Path,
@@ -69,7 +81,7 @@ pub async fn run(
             return Err(BcmrError::SourceNotFound(src.clone()));
         }
 
-        let (src_entries, dst_entries) = collect_both(
+        let collected = collect_both(
             src,
             dest,
             recursive,
@@ -80,7 +92,14 @@ pub async fn run(
         )
         .await?;
 
-        let (added, modified, missing) = diff_entries(src_entries, dst_entries);
+        let (added, modified, missing) = diff_entries(collected.src_entries, collected.dst_entries);
+        let modified = filter_size_match_via_hash(
+            modified,
+            &collected.src_root,
+            &collected.dst_root,
+            &mut serve_client,
+        )
+        .await?;
         all_added.extend(added);
         all_modified.extend(modified);
         all_missing.extend(missing);
@@ -101,7 +120,7 @@ async fn collect_both(
     is_remote_src: bool,
     is_remote_dest: bool,
     serve: &mut Option<ServeClient>,
-) -> Result<(Vec<Entry>, Vec<Entry>), BcmrError> {
+) -> Result<CollectResult, BcmrError> {
     let src_str = src.to_string_lossy();
     let dest_str = dest.to_string_lossy();
 
@@ -217,7 +236,68 @@ async fn collect_both(
         }
     };
 
-    Ok((src_entries, dst_entries))
+    let src_root = if let Some(ref rp) = remote_src {
+        if src_is_dir {
+            SideRoot::Remote(rp.clone())
+        } else {
+            SideRoot::Remote(remote_parent(rp))
+        }
+    } else if src_is_dir {
+        SideRoot::Local(src.to_path_buf())
+    } else {
+        SideRoot::Local(
+            src.parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| PathBuf::from(".")),
+        )
+    };
+
+    let dst_root = if is_remote_dest {
+        let rdest = parse_remote_path(&dest_str).ok_or_else(|| {
+            BcmrError::InvalidInput(format!("Invalid remote path: {}", dest.display()))
+        })?;
+        let rdest_is_dir = remote_is_dir(&rdest, serve).await.unwrap_or(false);
+        if rdest_is_dir {
+            SideRoot::Remote(rdest.join(&src_name))
+        } else if src_is_dir {
+            SideRoot::Remote(rdest)
+        } else {
+            SideRoot::Remote(remote_parent(&rdest))
+        }
+    } else {
+        let dest_is_dir = dest.exists() && dest.is_dir();
+        if dest_is_dir {
+            SideRoot::Local(dest.join(&src_name))
+        } else if src_is_dir {
+            SideRoot::Local(dest.to_path_buf())
+        } else {
+            SideRoot::Local(
+                dest.parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| PathBuf::from(".")),
+            )
+        }
+    };
+
+    Ok(CollectResult {
+        src_entries,
+        dst_entries,
+        src_root,
+        dst_root,
+    })
+}
+
+fn remote_parent(rp: &RemotePath) -> RemotePath {
+    let parent_path = match rp.path.rsplit_once('/') {
+        Some((p, _)) if !p.is_empty() => p.to_string(),
+        Some(_) => "/".to_string(),
+        None => ".".to_string(),
+    };
+    RemotePath {
+        user: rp.user.clone(),
+        host: rp.host.clone(),
+        path: parent_path,
+    }
 }
 
 async fn remote_is_dir(
@@ -335,6 +415,57 @@ fn mtime_secs(meta: &std::fs::Metadata) -> i64 {
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+async fn hash_at(
+    root: &SideRoot,
+    rel: &Path,
+    serve: &mut Option<ServeClient>,
+) -> Result<String, BcmrError> {
+    match root {
+        SideRoot::Local(base) => {
+            let abs = base.join(rel);
+            tokio::task::spawn_blocking(move || crate::core::checksum::calculate_hash(&abs))
+                .await
+                .map_err(|e| BcmrError::InvalidInput(e.to_string()))?
+                .map_err(BcmrError::Io)
+        }
+        SideRoot::Remote(base) => {
+            let target = base.join(&rel.to_string_lossy());
+            if let Some(client) = serve.as_mut() {
+                let bytes = client.hash(&target.path, 0, None).await?;
+                return Ok(bytes.iter().map(|b| format!("{:02x}", b)).collect());
+            }
+            remote::remote_file_hash(&target, None).await
+        }
+    }
+}
+
+async fn filter_size_match_via_hash(
+    candidates: Vec<FileDiff>,
+    src_root: &SideRoot,
+    dst_root: &SideRoot,
+    serve: &mut Option<ServeClient>,
+) -> Result<Vec<FileDiff>, BcmrError> {
+    let mut kept = Vec::with_capacity(candidates.len());
+    for diff in candidates {
+        if diff.is_dir {
+            kept.push(diff);
+            continue;
+        }
+        if diff.src_size != diff.dst_size {
+            kept.push(diff);
+            continue;
+        }
+        let rel = diff.path.clone();
+        let src_hash = hash_at(src_root, &rel, serve).await;
+        let dst_hash = hash_at(dst_root, &rel, serve).await;
+        match (src_hash, dst_hash) {
+            (Ok(s), Ok(d)) if s == d => {}
+            _ => kept.push(diff),
+        }
+    }
+    Ok(kept)
 }
 
 fn diff_entries(src: Vec<Entry>, dst: Vec<Entry>) -> (Vec<FileDiff>, Vec<FileDiff>, Vec<FileDiff>) {

--- a/tests/e2e_check_tests.rs
+++ b/tests/e2e_check_tests.rs
@@ -80,7 +80,31 @@ fn e2e_check_multi_source_detects_real_mismatch() {
 }
 
 #[test]
-fn e2e_check_same_size_different_mtime_is_modified() {
+fn e2e_check_same_content_drifted_mtime_into_dir_is_in_sync() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("x.bin");
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+    let dst = dst_dir.join("x.bin");
+    fs::write(&src, b"1234567890").unwrap();
+    fs::write(&dst, b"1234567890").unwrap();
+
+    let old = SystemTime::now() - Duration::from_secs(3600);
+    let ft = filetime::FileTime::from_system_time(old);
+    filetime::set_file_mtime(&dst, ft).unwrap();
+
+    let (ok, stdout, _stderr) = run_bcmr(&[
+        "check",
+        src.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(ok, "expected exit 0, got: {stdout}");
+    assert!(stdout.contains("\"in_sync\":true"), "got: {stdout}");
+}
+
+#[test]
+fn e2e_check_same_content_drifted_mtime_with_no_hash_reports_modified() {
     let dir = tempfile::tempdir().unwrap();
     let src = dir.path().join("x.bin");
     let dst_dir = dir.path().join("dst");
@@ -95,6 +119,7 @@ fn e2e_check_same_size_different_mtime_is_modified() {
 
     let (_, stdout, _stderr) = run_bcmr(&[
         "check",
+        "--no-hash",
         src.to_str().unwrap(),
         dst_dir.to_str().unwrap(),
         "--json",
@@ -104,4 +129,88 @@ fn e2e_check_same_size_different_mtime_is_modified() {
         stdout.contains("\"modified\":[{\"path\":\"x.bin\""),
         "got: {stdout}"
     );
+}
+
+#[test]
+fn e2e_check_file_to_file_same_size_diff_content_is_modified() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a.bin");
+    let b = dir.path().join("b.bin");
+    fs::write(&a, b"AAAAAA").unwrap();
+    fs::write(&b, b"BBBBBB").unwrap();
+
+    let now = SystemTime::now();
+    let ft = filetime::FileTime::from_system_time(now);
+    filetime::set_file_mtime(&a, ft).unwrap();
+    filetime::set_file_mtime(&b, ft).unwrap();
+
+    let (_, stdout, _stderr) =
+        run_bcmr(&["check", a.to_str().unwrap(), b.to_str().unwrap(), "--json"]);
+    assert!(stdout.contains("\"in_sync\":false"), "got: {stdout}");
+    assert!(
+        stdout.contains("\"modified\":[{\"path\":\"a.bin\""),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn e2e_check_file_to_file_same_content_is_in_sync() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a.bin");
+    let b = dir.path().join("b.bin");
+    fs::write(&a, b"hello world").unwrap();
+    fs::write(&b, b"hello world").unwrap();
+
+    let old = SystemTime::now() - Duration::from_secs(7200);
+    let ft = filetime::FileTime::from_system_time(old);
+    filetime::set_file_mtime(&b, ft).unwrap();
+
+    let (ok, stdout, _stderr) =
+        run_bcmr(&["check", a.to_str().unwrap(), b.to_str().unwrap(), "--json"]);
+    assert!(ok, "expected exit 0, got: {stdout}");
+    assert!(stdout.contains("\"in_sync\":true"), "got: {stdout}");
+}
+
+#[test]
+fn e2e_check_file_to_file_dst_missing_is_added() {
+    let dir = tempfile::tempdir().unwrap();
+    let a = dir.path().join("a.bin");
+    let b = dir.path().join("b.bin");
+    fs::write(&a, b"content").unwrap();
+
+    let (_, stdout, _stderr) =
+        run_bcmr(&["check", a.to_str().unwrap(), b.to_str().unwrap(), "--json"]);
+    assert!(stdout.contains("\"in_sync\":false"), "got: {stdout}");
+    assert!(
+        stdout.contains("\"added\":[{\"path\":\"a.bin\""),
+        "got: {stdout}"
+    );
+    assert!(stdout.contains("\"modified\":0"), "got: {stdout}");
+}
+
+#[test]
+fn e2e_check_dir_to_dir_size_match_drifted_mtime_is_in_sync() {
+    let dir = tempfile::tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_parent = dir.path().join("dst");
+    fs::create_dir(&src_dir).unwrap();
+    fs::create_dir(&dst_parent).unwrap();
+    let dst_mirror = dst_parent.join("src");
+    fs::create_dir(&dst_mirror).unwrap();
+    fs::write(src_dir.join("f.bin"), b"same content").unwrap();
+    fs::write(dst_mirror.join("f.bin"), b"same content").unwrap();
+
+    let old = SystemTime::now() - Duration::from_secs(3600);
+    let ft = filetime::FileTime::from_system_time(old);
+    filetime::set_file_mtime(dst_mirror.join("f.bin"), ft).unwrap();
+
+    let (ok, stdout, _stderr) = run_bcmr(&[
+        "check",
+        "-r",
+        src_dir.to_str().unwrap(),
+        dst_parent.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(ok, "expected exit 0, got: {stdout}");
+    assert!(stdout.contains("\"in_sync\":true"), "got: {stdout}");
 }


### PR DESCRIPTION
## Summary
\`bcmr check\` against a 0.6.0 server flagged every byte-identical file as "modified" whenever mtimes differed. 0.6.0's PUT doesn't preserve source mtime by default, so \`bcmr copy -r src host:dst/\` (no \`-p\`) followed by \`bcmr check -r src host:dst/\` printed every file as modified even though the bytes were identical. 0.5.20 happened to preserve mtime so the same workflow showed "In sync", but the client shouldn't have to know which server it's talking to.

Took the issue's option (2) — client-side hash. After \`diff_entries\` returns "modified" candidates:
- size-mismatch entries: keep as modified (definitively different).
- directories: keep (no hash semantics).
- size-match candidates: hash both ends; drop from modified iff hashes match.

Cost is zero on the common path (mtime+size already match → not a candidate). Hash fires only for size-match-mtime-mismatch entries — which is exactly the regression case the issue describes.

## Plumbing
\`collect_both\` now returns \`src_root\` / \`dst_root\` (\`SideRoot::Local\` or \`SideRoot::Remote\`) such that \`root.join(rel_path)\` resolves any Entry to an absolute path. This also makes \`dst_root\` carry the *resolved* dest base (e.g. \`rdest.join(src_name)\` when dest is a directory) — i.e. the directory files actually landed in, not the user-typed dest — so hashing matches on-disk layout.

## Verified on lunemira_sv (server 0.6.0)
| input | result |
|---|---|
| \`bcmr copy -r /tmp/tree lunemira_sv:dst42/\` (no \`-p\`) then check | \`In sync.\` (was: \`3 modified\`) |
| mutate \`a.txt\` size+content on remote, check | \`1 modified\` |
| same size, different content (hash mismatch) | \`1 modified\` |

## Test plan
- [x] \`cargo test --lib\` 79 passed.
- [x] All three end-to-end scenarios on lunemira_sv (0.6.0 server, in non-interactive PATH).

Closes #42