### PR TITLE
feat: bcmr update --check (read-only version probe) (#60)

### DIFF
--- a/src/app/updates.rs
+++ b/src/app/updates.rs
@@ -8,7 +8,7 @@ pub(crate) fn background_update_check(
 ) -> Option<mpsc::Receiver<Option<String>>> {
     if matches!(
         command,
-        Commands::Update
+        Commands::Update { .. }
             | Commands::Completions { .. }
             | Commands::CompleteRemote { .. }
             | Commands::Serve { .. }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -187,7 +187,11 @@ pub enum Commands {
     },
 
     /// Check for updates and self-update
-    Update,
+    Update {
+        /// Print the current and latest versions and exit, without installing.
+        #[arg(long)]
+        check: bool,
+    },
 
     #[command(name = "__complete-remote", hide = true)]
     CompleteRemote { partial: String },
@@ -649,7 +653,7 @@ mod tests {
 
     #[test]
     fn test_commands_non_file_defaults() {
-        let cmd = Commands::Update;
+        let cmd = Commands::Update { check: false };
         assert!(!cmd.is_recursive());
         assert!(!cmd.is_force());
         assert!(!cmd.is_preserve());

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -24,27 +24,52 @@ fn version_newer(latest: &str, current: &str) -> bool {
     parse(latest) > parse(current)
 }
 
-pub fn check_for_update() -> Option<String> {
+fn fetch_latest_version() -> Result<String> {
     let releases = self_update::backends::github::ReleaseList::configure()
         .repo_owner("Bengerthelorf")
         .repo_name("bcmr")
-        .build()
-        .ok()?
-        .fetch()
-        .ok()?;
+        .build()?
+        .fetch()?;
+    releases
+        .first()
+        .map(|r| r.version.clone())
+        .ok_or_else(|| anyhow::anyhow!("no releases found"))
+}
 
-    let latest = releases.first()?;
+pub fn check_for_update() -> Option<String> {
+    let latest = fetch_latest_version().ok()?;
     let current = cargo_crate_version!();
-
-    if version_newer(&latest.version, current) {
-        Some(latest.version.clone())
+    if version_newer(&latest, current) {
+        Some(latest)
     } else {
         None
     }
 }
 
-pub fn run() -> Result<()> {
+pub fn run(check_only: bool) -> Result<()> {
     let current = cargo_crate_version!();
+
+    if check_only {
+        let latest = fetch_latest_version()?;
+        let available = version_newer(&latest, current);
+        if crate::config::is_json_mode() {
+            let json = serde_json::json!({
+                "current": current,
+                "latest": latest,
+                "update_available": available,
+            });
+            println!("{}", json);
+        } else {
+            println!("Current version: {}", current);
+            if available {
+                println!("Latest version:  {} (update available)", latest);
+            } else {
+                println!("Latest version:  {} (up to date)", latest);
+            }
+        }
+        return Ok(());
+    }
+
     println!("Current version: {}", current);
     println!("Checking for updates...");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,10 @@ async fn main() -> Result<()> {
             handle_status_command(job_id);
         }
         Commands::Init { .. } => handle_init_command(&cli.command)?,
-        Commands::Update => commands::update::run()?,
+        Commands::Update { check } => {
+            let check = *check;
+            tokio::task::spawn_blocking(move || commands::update::run(check)).await??;
+        }
         Commands::Serve { root, listen } => {
             if let Some(addr) = listen {
                 let parsed: std::net::SocketAddr = addr.parse().map_err(|e| {


### PR DESCRIPTION
## Summary
`bcmr update` had no read-only mode — running it would immediately download and replace the binary. Add `--check`: fetch the latest GitHub release tag, print current + latest + whether an update is available, then exit without touching the install.

## Output

```
$ bcmr update --check
Current version: 0.6.0
Latest version:  0.6.0 (up to date)

$ bcmr update --check --json
{"current":"0.6.0","latest":"0.6.0","update_available":false}
```

## Implementation notes
- Pulled `fetch_latest_version` out of `check_for_update` so the new flag and the existing background-update-check share one GitHub probe path.
- Wrapped the dispatcher in `spawn_blocking` so `self_update`'s synchronous HTTP client doesn't panic dropping its inner tokio runtime inside the bcmr async main — applies to both `--check` and the existing install path (the install was carrying a latent crash risk that hadn't been triggered yet).
- The issue listed `--version <X>` and `--yes` as nice-to-have follow-ups; this PR is just `--check`.

## Test plan
- [x] `bcmr update --check` text + JSON output verified.
- [x] `bcmr update --help` shows the new flag.
- [x] `cargo test --lib` 79 passed.
- [x] Live install path (`bcmr update` without `--check`): runs `Checking target-arch... / current version... / latest released version... Already up to date.` against the same-version GitHub release; binary mtime unchanged → spawn_blocking wrap is inert for the install path as expected.

Closes #60