### PR TITLE
feat: bcmr copy --no-deref preserves symlinks (local) (#47)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -165,16 +165,23 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
             None
         };
 
-        let plan =
-            match commands::copy::plan_copy(sources, dest, args.is_recursive(), &excludes).await {
-                Ok(p) => p,
-                Err(e) => {
-                    if let Some(r) = early {
-                        r.finish_with_error(&e.to_string());
-                    }
-                    return Err(e.into());
+        let plan = match commands::copy::plan_copy(
+            sources,
+            dest,
+            args.is_recursive(),
+            args.is_no_deref(),
+            &excludes,
+        )
+        .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                if let Some(r) = early {
+                    r.finish_with_error(&e.to_string());
                 }
-            };
+                return Err(e.into());
+            }
+        };
 
         if args.is_force()
             && !plan.overwrites.is_empty()
@@ -282,6 +289,13 @@ pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
 
     let excludes = args.compile_excludes()?;
     let (sources, dest) = args.get_sources_and_dest().map_err(anyhow::Error::msg)?;
+
+    if args.is_no_deref() {
+        bail!(
+            "--no-deref is not yet supported for bcmr move; use bcmr copy --no-deref \
+             then bcmr remove on the originals, or scp -p / rsync."
+        );
+    }
 
     for src in sources {
         validate_source_kind(src)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,6 +103,10 @@ pub struct CopyMoveArgs {
     #[arg(short = 'a', long, default_value_t = false)]
     pub append: bool,
 
+    /// Don't follow symbolic links — replicate the link itself at the destination (cp -P)
+    #[arg(long = "no-deref", default_value_t = false)]
+    pub no_deref: bool,
+
     /// Sync data to disk after operation (fsync)
     #[arg(long, default_value_t = false)]
     pub sync: bool,
@@ -381,6 +385,10 @@ impl Commands {
         self.copy_move_args().is_some_and(|a| a.append)
     }
 
+    pub fn is_no_deref(&self) -> bool {
+        self.copy_move_args().is_some_and(|a| a.no_deref)
+    }
+
     pub fn is_sync(&self) -> bool {
         self.copy_move_args().is_some_and(|a| a.sync)
     }
@@ -569,6 +577,7 @@ mod tests {
             resume: false,
             strict: false,
             append: false,
+            no_deref: false,
             sync: false,
             jobs: None,
             compress: "auto".to_string(),

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -55,9 +55,69 @@ impl Drop for TempFileGuard {
     }
 }
 
+pub(crate) fn check_symlink_overwrite(
+    dst: &Path,
+    cli: &Commands,
+) -> std::result::Result<(), BcmrError> {
+    let Ok(md) = dst.symlink_metadata() else {
+        return Ok(());
+    };
+    // cp -P refuses to clobber a real directory with a symlink even under -f.
+    let ft = md.file_type();
+    if ft.is_dir() && !ft.is_symlink() {
+        return Err(BcmrError::InvalidInput(format!(
+            "cannot overwrite directory '{}' with a symlink",
+            dst.display()
+        )));
+    }
+    if !cli.is_force() {
+        return Err(BcmrError::TargetExists(dst.to_path_buf()));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) async fn create_symlink_replacing(
+    dst: &Path,
+    target: &Path,
+) -> std::result::Result<(), BcmrError> {
+    // Caller must have run `check_symlink_overwrite` first; non-symlink directories never reach here.
+    if dst.symlink_metadata().is_ok() {
+        fs::remove_file(dst).await?;
+    }
+    let dst = dst.to_path_buf();
+    let target = target.to_path_buf();
+    tokio::task::spawn_blocking(move || std::os::unix::fs::symlink(&target, &dst))
+        .await
+        .map_err(|e| BcmrError::InvalidInput(e.to_string()))?
+        .map_err(BcmrError::Io)
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn create_symlink_replacing(
+    _dst: &Path,
+    _target: &Path,
+) -> std::result::Result<(), BcmrError> {
+    Err(BcmrError::InvalidInput(
+        "symlink replication is not supported on this platform".into(),
+    ))
+}
+
+#[cfg_attr(test, derive(Debug))]
 pub enum PlanEntry {
-    CreateDir { src: PathBuf, dst: PathBuf },
-    CopyFile { src: PathBuf, dst: PathBuf },
+    CreateDir {
+        src: PathBuf,
+        dst: PathBuf,
+    },
+    CopyFile {
+        src: PathBuf,
+        dst: PathBuf,
+    },
+    Symlink {
+        src: PathBuf,
+        dst: PathBuf,
+        target: PathBuf,
+    },
 }
 
 pub struct CopyPlan {
@@ -70,13 +130,41 @@ pub(super) fn scan_sources(
     sources: &[PathBuf],
     dst: &Path,
     recursive: bool,
+    no_deref: bool,
     excludes: &[regex::Regex],
     mut on_entry: impl FnMut(PlanEntry, u64) -> std::result::Result<(), BcmrError>,
 ) -> std::result::Result<(), BcmrError> {
     let dst_is_dir = dst.exists() && dst.is_dir();
 
+    let is_symlink = |p: &Path| -> bool {
+        p.symlink_metadata()
+            .map(|m| m.is_symlink())
+            .unwrap_or(false)
+    };
+
     for src in sources {
         if traversal::is_excluded(src, excludes) {
+            continue;
+        }
+
+        if no_deref && is_symlink(src) {
+            let target = std::fs::read_link(src).map_err(BcmrError::Io)?;
+            let dst_path =
+                if dst_is_dir {
+                    dst.join(src.file_name().ok_or_else(|| {
+                        BcmrError::InvalidInput("Invalid source file name".into())
+                    })?)
+                } else {
+                    dst.to_path_buf()
+                };
+            on_entry(
+                PlanEntry::Symlink {
+                    src: src.clone(),
+                    dst: dst_path,
+                    target,
+                },
+                0,
+            )?;
             continue;
         }
 
@@ -122,7 +210,17 @@ pub(super) fn scan_sources(
                 let relative = path.strip_prefix(src)?;
                 let target = new_dst.join(relative);
 
-                if path.is_dir() {
+                if no_deref && is_symlink(path) {
+                    let link_target = std::fs::read_link(path).map_err(BcmrError::Io)?;
+                    on_entry(
+                        PlanEntry::Symlink {
+                            src: path.to_path_buf(),
+                            dst: target,
+                            target: link_target,
+                        },
+                        0,
+                    )?;
+                } else if path.is_dir() {
                     on_entry(
                         PlanEntry::CreateDir {
                             src: path.to_path_buf(),
@@ -158,34 +256,39 @@ fn plan_copy_sync(
     sources: Vec<PathBuf>,
     dst: PathBuf,
     recursive: bool,
+    no_deref: bool,
     excludes: Vec<regex::Regex>,
 ) -> std::result::Result<CopyPlan, BcmrError> {
     let mut entries = Vec::new();
     let mut total_size = 0u64;
     let mut overwrites = Vec::new();
 
-    scan_sources(&sources, &dst, recursive, &excludes, |entry, size| {
-        total_size += size;
+    scan_sources(
+        &sources,
+        &dst,
+        recursive,
+        no_deref,
+        &excludes,
+        |entry, size| {
+            total_size += size;
 
-        let target = match &entry {
-            PlanEntry::CopyFile { dst, .. } => Some((dst.clone(), false)),
-            PlanEntry::CreateDir { dst, .. } => {
-                if dst.exists() {
-                    Some((dst.clone(), true))
-                } else {
-                    None
+            let target = match &entry {
+                PlanEntry::CopyFile { dst, .. } | PlanEntry::Symlink { dst, .. } => {
+                    Some((dst.clone(), false))
+                }
+                PlanEntry::CreateDir { dst, .. } if dst.exists() => Some((dst.clone(), true)),
+                PlanEntry::CreateDir { .. } => None,
+            };
+            if let Some((path, is_dir)) = target {
+                if path.exists() && !traversal::is_excluded(&path, &excludes) {
+                    overwrites.push(FileToOverwrite { path, is_dir });
                 }
             }
-        };
-        if let Some((path, is_dir)) = target {
-            if path.exists() && !traversal::is_excluded(&path, &excludes) {
-                overwrites.push(FileToOverwrite { path, is_dir });
-            }
-        }
 
-        entries.push(entry);
-        Ok(())
-    })?;
+            entries.push(entry);
+            Ok(())
+        },
+    )?;
 
     Ok(CopyPlan {
         entries,
@@ -198,12 +301,14 @@ pub async fn plan_copy(
     sources: &[PathBuf],
     dst: &Path,
     recursive: bool,
+    no_deref: bool,
     excludes: &[regex::Regex],
 ) -> std::result::Result<CopyPlan, BcmrError> {
     let sources = sources.to_vec();
     let dst = dst.to_path_buf();
     let excludes = excludes.to_vec();
-    tokio::task::spawn_blocking(move || plan_copy_sync(sources, dst, recursive, excludes)).await?
+    tokio::task::spawn_blocking(move || plan_copy_sync(sources, dst, recursive, no_deref, excludes))
+        .await?
 }
 
 pub fn dry_run_plan(plan: &CopyPlan, cli: &Commands) -> std::result::Result<(), BcmrError> {
@@ -221,6 +326,22 @@ pub fn dry_run_plan(plan: &CopyPlan, cli: &Commands) -> std::result::Result<(), 
             PlanEntry::CopyFile { src, dst } => {
                 let action = determine_dry_run_action(src, dst, cli)?;
                 print_dry_run(action, &src.to_string_lossy(), Some(&dst.to_string_lossy()));
+            }
+            PlanEntry::Symlink { src, dst, target } => {
+                let action = if dst.symlink_metadata().is_ok() {
+                    ActionType::Overwrite
+                } else {
+                    ActionType::Add
+                };
+                print_dry_run(
+                    action,
+                    &src.to_string_lossy(),
+                    Some(&format!(
+                        "(SYMLINK -> {}) -> {}",
+                        target.display(),
+                        dst.display()
+                    )),
+                );
             }
         }
     }
@@ -254,6 +375,16 @@ where
 
     let jobs = cli.local_jobs();
     let verbose = cli.is_verbose();
+
+    for entry in &plan.entries {
+        if let PlanEntry::Symlink { dst, target, .. } = entry {
+            check_symlink_overwrite(dst, cli)?;
+            create_symlink_replacing(dst, target).await?;
+            if verbose {
+                eprintln!("'{}' -> '{}' (symlink)", target.display(), dst.display());
+            }
+        }
+    }
 
     let file_entries: Vec<(&PathBuf, &PathBuf)> = plan
         .entries
@@ -523,4 +654,115 @@ pub(crate) async fn verify_copy(
         return Err(BcmrError::VerificationError(dst.to_path_buf()));
     }
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod scan_tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    fn collect(src: &PathBuf, dst: &Path, recursive: bool, no_deref: bool) -> Vec<PlanEntry> {
+        let mut out = Vec::new();
+        scan_sources(
+            std::slice::from_ref(src),
+            dst,
+            recursive,
+            no_deref,
+            &[],
+            |entry, _| {
+                out.push(entry);
+                Ok(())
+            },
+        )
+        .unwrap();
+        out
+    }
+
+    fn write(p: &Path, body: &[u8]) {
+        std::fs::write(p, body).unwrap();
+    }
+
+    #[test]
+    fn scan_emits_symlink_entry_for_top_level_link() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join("target.txt"), b"x");
+        let link = dir.path().join("link.txt");
+        symlink("target.txt", &link).unwrap();
+        let dst = dir.path().join("dst");
+        std::fs::create_dir(&dst).unwrap();
+
+        let entries = collect(&link, &dst, false, true);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            PlanEntry::Symlink {
+                src,
+                dst: d,
+                target,
+            } => {
+                assert_eq!(src, &link);
+                assert_eq!(d, &dst.join("link.txt"));
+                assert_eq!(target, std::path::Path::new("target.txt"));
+            }
+            other => panic!("expected Symlink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scan_without_no_deref_emits_copyfile_for_link() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir.path().join("target.txt"), b"x");
+        let link = dir.path().join("link.txt");
+        symlink("target.txt", &link).unwrap();
+        let dst = dir.path().join("dst");
+        std::fs::create_dir(&dst).unwrap();
+
+        let entries = collect(&link, &dst, false, false);
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(entries[0], PlanEntry::CopyFile { .. }));
+    }
+
+    #[test]
+    fn scan_recursive_emits_symlink_inside_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("tree");
+        std::fs::create_dir(&src).unwrap();
+        write(&src.join("a.txt"), b"a");
+        symlink("a.txt", src.join("rel.lnk")).unwrap();
+        let dst = dir.path().join("dst");
+        std::fs::create_dir(&dst).unwrap();
+
+        let entries = collect(&src, &dst, true, true);
+        let symlink_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| matches!(e, PlanEntry::Symlink { .. }))
+            .collect();
+        assert_eq!(
+            symlink_entries.len(),
+            1,
+            "expected exactly one Symlink entry"
+        );
+        let copy_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| matches!(e, PlanEntry::CopyFile { .. }))
+            .collect();
+        assert_eq!(copy_entries.len(), 1);
+    }
+
+    #[test]
+    fn scan_emits_symlink_for_dangling_link() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("broken.lnk");
+        symlink("nonexistent", &link).unwrap();
+        let dst = dir.path().join("dst");
+        std::fs::create_dir(&dst).unwrap();
+
+        let entries = collect(&link, &dst, false, true);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            PlanEntry::Symlink { target, .. } => {
+                assert_eq!(target, std::path::Path::new("nonexistent"));
+            }
+            other => panic!("expected Symlink, got {other:?}"),
+        }
+    }
 }

--- a/src/commands/copy/pipeline_batch.rs
+++ b/src/commands/copy/pipeline_batch.rs
@@ -38,6 +38,7 @@ where
 {
     let test_mode = cli.get_test_mode();
     let recursive = cli.is_recursive();
+    let no_deref = cli.is_no_deref();
     let jobs = cli.local_jobs();
     let verbose = cli.is_verbose();
     let callback = ProgressCallback {
@@ -57,18 +58,25 @@ where
         let mut total_size = 0u64;
         let mut files_found = 0u64;
 
-        let result = scan_sources(&sources, &dst, recursive, &excludes, |entry, size| {
-            total_size += size;
-            if size > 0 {
-                files_found += 1;
-                on_total_update(total_size);
-                on_file_found(files_found);
-            }
-            if tx.blocking_send(ScanMessage::Entry(entry)).is_err() {
-                return Ok(());
-            }
-            Ok(())
-        });
+        let result = scan_sources(
+            &sources,
+            &dst,
+            recursive,
+            no_deref,
+            &excludes,
+            |entry, size| {
+                total_size += size;
+                if size > 0 {
+                    files_found += 1;
+                    on_total_update(total_size);
+                    on_file_found(files_found);
+                }
+                if tx.blocking_send(ScanMessage::Entry(entry)).is_err() {
+                    return Ok(());
+                }
+                Ok(())
+            },
+        );
 
         let _ = tx.blocking_send(ScanMessage::Done);
         result
@@ -107,6 +115,17 @@ where
                         }
                         Ok::<(), BcmrError>(())
                     });
+                }
+                PlanEntry::Symlink {
+                    ref dst,
+                    ref target,
+                    ..
+                } => {
+                    super::check_symlink_overwrite(dst, cli)?;
+                    super::create_symlink_replacing(dst, target).await?;
+                    if verbose {
+                        eprintln!("'{}' -> '{}' (symlink)", target.display(), dst.display());
+                    }
                 }
             },
             ScanMessage::Done => {

--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -229,6 +229,14 @@ pub async fn handle_remote_copy(
     let remote_dest_initial = parse_remote_path(&dest_str);
     let is_upload = remote_dest_initial.is_some();
 
+    if args.is_no_deref() {
+        anyhow::bail!(
+            "--no-deref is currently only supported for local-to-local copies. \
+             For symlink-aware remote transfers, use scp/rsync directly until \
+             bcmr's serve protocol grows symlink semantics."
+        );
+    }
+
     if let Some(ref rd) = remote_dest_initial {
         rd.reject_unsafe()?;
     }

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -59,6 +59,13 @@ fn files_match(a: &Path, b: &Path) -> bool {
     ha == hb
 }
 
+#[cfg(unix)]
+fn is_symlink(p: &Path) -> bool {
+    p.symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
 fn session_exists(src: &Path, dst: &Path) -> bool {
     Session::session_path(src, dst).exists()
 }
@@ -658,4 +665,344 @@ fn test_xattr_preserves_binary_value() {
 
     let got = xattr::get(&dst, "user.bcmr.bin").unwrap().unwrap();
     assert_eq!(got, binary_value);
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_replicates_top_level_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"target body").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "--no-deref",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}");
+
+    let landed = dst_dir.join("link.txt");
+    assert!(is_symlink(&landed));
+    assert_eq!(
+        std::fs::read_link(&landed).unwrap(),
+        std::path::Path::new("target.txt")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_default_dereferences() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"derefed").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+
+    let (ok, _, _) = run_bcmr(&[
+        "copy",
+        "-t",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(ok);
+
+    let landed = dst_dir.join("link.txt");
+    assert!(landed.symlink_metadata().unwrap().file_type().is_file());
+    assert_eq!(fs::read(&landed).unwrap(), b"derefed");
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_preserves_dangling_symlink() {
+    let dir = tempfile::tempdir().unwrap();
+    let link = dir.path().join("broken.txt");
+    std::os::unix::fs::symlink("nonexistent", &link).unwrap();
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+
+    let (ok, _, _) = run_bcmr(&[
+        "copy",
+        "-t",
+        "--no-deref",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(ok);
+
+    let landed = dst_dir.join("broken.txt");
+    assert!(landed.symlink_metadata().is_ok());
+    assert_eq!(
+        std::fs::read_link(&landed).unwrap(),
+        std::path::Path::new("nonexistent")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_recursive_preserves_nested_links() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("tree");
+    fs::create_dir(&src).unwrap();
+    fs::write(src.join("a.txt"), b"a").unwrap();
+    let sub = src.join("sub");
+    fs::create_dir(&sub).unwrap();
+    fs::write(sub.join("real.txt"), b"real").unwrap();
+    std::os::unix::fs::symlink("real.txt", sub.join("rel_link.txt")).unwrap();
+    std::os::unix::fs::symlink(src.join("a.txt"), src.join("abs_link.txt")).unwrap();
+
+    let dst_root = dir.path().join("dst");
+    fs::create_dir(&dst_root).unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-rt",
+        "--no-deref",
+        src.to_str().unwrap(),
+        dst_root.to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}");
+
+    let landed = dst_root.join("tree");
+    assert!(landed.join("a.txt").is_file());
+    let rel = landed.join("sub/rel_link.txt");
+    assert!(is_symlink(&rel));
+    assert_eq!(
+        std::fs::read_link(&rel).unwrap(),
+        std::path::Path::new("real.txt")
+    );
+    let abs = landed.join("abs_link.txt");
+    assert!(is_symlink(&abs));
+    // Absolute targets stay verbatim — bcmr doesn't rewrite them relative to dst.
+    assert_eq!(std::fs::read_link(&abs).unwrap(), src.join("a.txt"));
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_overwrite_gate_refuses_existing_dst() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"target").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+    let collide = dst_dir.join("link.txt");
+    fs::write(&collide, b"PRE").unwrap();
+    let pre_hash = checksum::calculate_hash(&collide).unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "--no-deref",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(stderr.contains("already exists") || stderr.contains("TargetExists"));
+    assert!(collide.is_file());
+    assert_eq!(checksum::calculate_hash(&collide).unwrap(), pre_hash);
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_overwrite_with_force_replaces() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"target").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+    let collide = dst_dir.join("link.txt");
+    fs::write(&collide, b"PRE").unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-tfy",
+        "--no-deref",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}");
+
+    assert!(is_symlink(&collide));
+    assert_eq!(
+        std::fs::read_link(&collide).unwrap(),
+        std::path::Path::new("target.txt")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_overwrite_gate_treats_dangling_link_as_existing() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"new").unwrap();
+    let src_link = dir.path().join("src_link.txt");
+    std::os::unix::fs::symlink("target.txt", &src_link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+    let dangling = dst_dir.join("src_link.txt");
+    std::os::unix::fs::symlink("does_not_exist", &dangling).unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "--no-deref",
+        src_link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(stderr.contains("already exists") || stderr.contains("TargetExists"));
+    assert_eq!(
+        std::fs::read_link(&dangling).unwrap(),
+        std::path::Path::new("does_not_exist")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_replicates_top_level_symlink_to_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let real_dir = dir.path().join("real_dir");
+    fs::create_dir(&real_dir).unwrap();
+    fs::write(real_dir.join("inside.txt"), b"x").unwrap();
+    let link = dir.path().join("link_to_dir");
+    std::os::unix::fs::symlink("real_dir", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "--no-deref",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}");
+
+    let landed = dst_dir.join("link_to_dir");
+    assert!(is_symlink(&landed));
+    assert_eq!(
+        std::fs::read_link(&landed).unwrap(),
+        std::path::Path::new("real_dir")
+    );
+    // The link target's contents must NOT be walked into and copied.
+    assert!(!dst_dir.join("link_to_dir/inside.txt").exists() || is_symlink(&landed));
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_multi_source_mix() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("real.txt"), b"real").unwrap();
+    fs::write(dir.path().join("target.txt"), b"target").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "--no-deref",
+        dir.path().join("real.txt").to_str().unwrap(),
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}");
+
+    let real_dst = dst_dir.join("real.txt");
+    let link_dst = dst_dir.join("link.txt");
+    assert!(real_dst.symlink_metadata().unwrap().file_type().is_file());
+    assert_eq!(fs::read(&real_dst).unwrap(), b"real");
+    assert!(is_symlink(&link_dst));
+    assert_eq!(
+        std::fs::read_link(&link_dst).unwrap(),
+        std::path::Path::new("target.txt")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_refuses_overwriting_directory_even_with_force() {
+    // cp -P semantics: --force overwrites files / symlinks, never directories.
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"x").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+    let collide = dst_dir.join("link.txt");
+    fs::create_dir(&collide).unwrap();
+    fs::write(collide.join("inside.txt"), b"keep").unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-tfy",
+        "--no-deref",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(stderr.contains("cannot overwrite directory"));
+    assert!(collide.is_dir());
+    assert!(collide.join("inside.txt").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_dry_run_emits_overwrite_for_existing_dst() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"x").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir(&dst_dir).unwrap();
+    fs::write(dst_dir.join("link.txt"), b"PRE").unwrap();
+
+    let (ok, stdout, stderr) = run_bcmr(&[
+        "copy",
+        "-tnfy",
+        "--no-deref",
+        link.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}");
+    let lower = stdout.to_lowercase();
+    assert!(
+        lower.contains("overwrite"),
+        "expected OVERWRITE in dry-run, got: {stdout}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn e2e_no_deref_remote_target_refuses() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("target.txt"), b"x").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+    let (ok, _, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "--no-deref",
+        link.to_str().unwrap(),
+        "no-such-host-bcmr-test.invalid:dst/",
+    ]);
+    assert!(!ok);
+    assert!(stderr.contains("--no-deref is currently only supported for local"));
 }


### PR DESCRIPTION
## Summary
Every symlink in a bcmr copy was dereferenced — target bytes ended up at the destination as a regular file, with no flag to opt out. Add \`--no-deref\` (long-only; \`-P\` is already \`bcmr copy --parallel\`'s short flag).

## In scope
Local-to-local copies, including:
- top-level symlink sources (\`bcmr copy --no-deref link.txt /dst/\`)
- symlinks discovered during \`-r\` traversal
- **broken** symlinks (target doesn't exist) — replicated as-is, matching \`cp -P\`

Implementation:
- New \`PlanEntry::Symlink { src, dst, target }\`.
- \`scan_sources\` checks \`symlink_metadata().is_symlink()\` before the regular file/dir branches when \`no_deref\` is set (top-level + walk body).
- \`create_symlink_replacing\` removes the existing dst (file or dir) and writes the new link via \`std::os::unix::fs::symlink\`.
- \`execute_plan\` and \`pipeline_batch\` both wire in the new entry kind.
- Dry-run prints \`(SYMLINK -> target) -> dst\`.

## Out of scope (errored upfront)
- **Remote copy + \`--no-deref\`**: the serve protocol has no symlink message; legacy fallback's single-quoted shell args wouldn't carry \`ln -s\` cleanly. Both paths need design work and deserve a dedicated PR.
- **\`bcmr move --no-deref\`**: mv-on-symlink semantics differ enough from cp -P that it should be its own change.

Both error with a clear message naming the workaround.

## Why long-only \`--no-deref\` (no \`-P\`)
\`-P\` is already \`bcmr copy --parallel\`'s short flag. \`-P\` for "no dereference" would have been a breaking flag rename; long-only avoids the conflict and matches the most explicit reading.

## Verified locally on macOS
| input | result |
|---|---|
| \`bcmr copy --no-deref /tmp/sym/link.txt /tmp/dst/\` | \`link.txt -> target.txt\` (symlink) |
| \`bcmr copy -r --no-deref /tmp/sym /tmp/dst/\` | tree copied; broken-link preserved as broken |
| no flag (regression) | \`link.txt\` (regular file, deref'd as before) |
| remote + \`--no-deref\` | clean error |
| move + \`--no-deref\` | clean error |

## Test plan
- [x] All five cases above end-to-end.
- [x] \`cargo test --lib\` 79 passed.

Closes #47