### PR TITLE
fix(remote): refuse remote-to-remote copy/move with clear error (#69)

### DIFF
--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -207,6 +207,26 @@ pub(super) fn collect_upload_files(
     Ok(items)
 }
 
+fn reject_remote_to_remote(sources: &[PathBuf], remote_dest: &Option<RemotePath>) -> Result<()> {
+    let Some(rdest) = remote_dest else {
+        return Ok(());
+    };
+    let Some(first_remote) = sources
+        .iter()
+        .find(|s| parse_remote_path(&s.to_string_lossy()).is_some())
+    else {
+        return Ok(());
+    };
+    anyhow::bail!(
+        "bcmr does not support remote-to-remote transfers ({} -> {}).\n\
+         Copy via a local intermediate: \
+         bcmr copy <src-host>:src /tmp/staging/ && \
+         bcmr copy /tmp/staging/<basename> <dst-host>:dst/",
+        first_remote.display(),
+        rdest.display(),
+    );
+}
+
 pub(super) fn resolve_upload_remote(
     src: &std::path::Path,
     rdest: &RemotePath,
@@ -228,6 +248,8 @@ pub async fn handle_remote_copy(
     let dest_str = dest.to_string_lossy();
     let remote_dest_initial = parse_remote_path(&dest_str);
     let is_upload = remote_dest_initial.is_some();
+
+    reject_remote_to_remote(sources, &remote_dest_initial)?;
 
     if args.is_no_deref() {
         anyhow::bail!(

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -1006,3 +1006,49 @@ fn e2e_no_deref_remote_target_refuses() {
     assert!(!ok);
     assert!(stderr.contains("--no-deref is currently only supported for local"));
 }
+
+#[test]
+fn e2e_cross_host_copy_refuses_with_clear_error() {
+    let (ok, _stdout, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "host-a-bcmr-test.invalid:src.bin",
+        "host-b-bcmr-test.invalid:dst/",
+    ]);
+    assert!(!ok, "expected non-zero exit");
+    assert!(
+        stderr.contains("does not support remote-to-remote"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("local intermediate"), "stderr: {stderr}");
+}
+
+#[test]
+fn e2e_same_host_remote_to_remote_copy_refuses() {
+    let (ok, _stdout, stderr) = run_bcmr(&[
+        "copy",
+        "-t",
+        "host-x-bcmr-test.invalid:src.bin",
+        "host-x-bcmr-test.invalid:dst/",
+    ]);
+    assert!(!ok);
+    assert!(
+        stderr.contains("does not support remote-to-remote"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn e2e_cross_host_move_refuses_with_clear_error() {
+    let (ok, _stdout, stderr) = run_bcmr(&[
+        "move",
+        "-t",
+        "host-a-bcmr-test.invalid:src.bin",
+        "host-b-bcmr-test.invalid:dst/",
+    ]);
+    assert!(!ok, "expected non-zero exit");
+    assert!(
+        stderr.contains("does not support remote-to-remote"),
+        "stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #69. \`bcmr copy host1:foo host2:bar/\` previously printed \`Done: 0 B in 0.2s\` and exited 0 with no transfer done — the same silent-success failure family as #35 / #36 / #52 / #58 / #59.

The dispatch fell into \`handle_remote_copy\` but neither the upload nor the download branch matched, leaving zero work done and the user thinking the transfer succeeded.

## Fix

Adds a fail-fast guard at the top of \`handle_remote_copy\` that runs before any I/O and rejects when any source is remote AND the destination is also remote. Both \`bcmr copy\` and \`bcmr move\` dispatch through this function, so a single guard covers both flows.

\`\`\`
$ bcmr copy 4090:nonexistent.txt lthpc:bar/
Error: bcmr does not support remote-to-remote transfers (4090:nonexistent.txt -> lthpc:bar/).
Copy via a local intermediate: bcmr copy <src-host>:src /tmp/staging/ && bcmr copy /tmp/staging/<basename> <dst-host>:dst/
$ echo $?
1
\`\`\`

Covers cross-host, same-host remote-to-remote, and mixed (local + remote source with remote dest) — anything where two ends are remote is unsupported and now refused before any I/O.

Single-host upload and download paths verified live on a real host (4090); behavior unchanged.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] New e2e tests using \`.invalid\` TLD (RFC 2606, no DNS lookup): \`e2e_cross_host_copy_refuses_with_clear_error\`, \`e2e_cross_host_move_refuses_with_clear_error\`, \`e2e_same_host_remote_to_remote_copy_refuses\`
- [x] Live: \`bcmr copy 4090:x lthpc:y/\` errors cleanly (was silent no-op)
- [x] Live: \`bcmr copy /tmp/h.txt 4090:/tmp/\` (single-host upload) still works
- [x] Live: \`bcmr copy 4090:/tmp/h.txt /tmp/back.txt\` (single-host download) still works