### PR TITLE
feat(cli): rename --tui to --plain, keep aliases for compat (#77)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,9 +76,9 @@ pub struct CopyMoveArgs {
     #[arg(short = 'e', long)]
     pub exclude: Option<Vec<String>>,
 
-    /// Enable inline TUI mode (classic 3-line display)
-    #[arg(short, long)]
-    pub tui: bool,
+    /// Use plain inline progress (3-line) instead of the fancy TUI box
+    #[arg(long, alias = "tui", short_alias = 't')]
+    pub plain: bool,
 
     /// Run in dry-run mode (no changes)
     #[arg(short = 'n', long)]
@@ -285,9 +285,9 @@ pub enum Commands {
         #[arg(short = 'e', long, value_name = "PATTERN", value_delimiter = ',')]
         exclude: Option<Vec<String>>,
 
-        /// Enable inline TUI mode (classic 3-line display)
-        #[arg(short, long)]
-        tui: bool,
+        /// Use plain inline progress (3-line) instead of the fancy TUI box
+        #[arg(long, alias = "tui", short_alias = 't')]
+        plain: bool,
 
         /// Run in dry-run mode (no changes)
         #[arg(short = 'n', long)]
@@ -351,9 +351,9 @@ impl Commands {
         }
     }
 
-    pub fn is_tui_mode(&self) -> bool {
-        self.copy_move_args().is_some_and(|a| a.tui)
-            || matches!(self, Commands::Remove { tui: true, .. })
+    pub fn is_plain_progress(&self) -> bool {
+        self.copy_move_args().is_some_and(|a| a.plain)
+            || matches!(self, Commands::Remove { plain: true, .. })
     }
 
     pub fn is_dry_run(&self) -> bool {
@@ -574,7 +574,7 @@ mod tests {
             yes: false,
             verbose: false,
             exclude: None,
-            tui: false,
+            plain: false,
             dry_run: false,
             test_mode: None,
             verify: false,
@@ -616,7 +616,7 @@ mod tests {
         assert!(!cmd.is_yes());
         assert!(cmd.is_verbose());
         assert!(cmd.is_dry_run());
-        assert!(!cmd.is_tui_mode());
+        assert!(!cmd.is_plain_progress());
         assert!(cmd.is_verify());
         assert!(cmd.is_resume());
         assert!(cmd.is_strict());
@@ -657,7 +657,7 @@ mod tests {
             verbose: false,
             dir: true,
             exclude: None,
-            tui: false,
+            plain: false,
             dry_run: false,
             test_mode: None,
         };

--- a/src/commands/remote_copy.rs
+++ b/src/commands/remote_copy.rs
@@ -27,7 +27,7 @@ pub(super) fn transfer_options_from_cli(cli: &Commands) -> remote::TransferOptio
 }
 
 pub fn is_plain_mode(args: &Commands) -> bool {
-    args.is_tui_mode() || CONFIG.progress.style.eq_ignore_ascii_case("plain")
+    args.is_plain_progress() || CONFIG.progress.style.eq_ignore_ascii_case("plain")
 }
 
 pub(super) struct TransferItem {

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -184,8 +184,8 @@ pub async fn remove_path(
         return Ok(());
     }
 
-    let is_tui = cli.is_tui_mode();
-    if cli.is_interactive() && !cli.is_force() && !confirm_remove(path, is_dir, is_tui).await? {
+    let plain = cli.is_plain_progress();
+    if cli.is_interactive() && !cli.is_force() && !confirm_remove(path, is_dir, plain).await? {
         return Ok(());
     }
 
@@ -217,7 +217,7 @@ pub async fn remove_path(
 
             if cli.is_interactive()
                 && !cli.is_force()
-                && !confirm_remove(entry_path, ft.is_dir(), is_tui).await?
+                && !confirm_remove(entry_path, ft.is_dir(), plain).await?
             {
                 continue;
             }

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -1024,6 +1024,34 @@ fn e2e_cross_host_copy_refuses_with_clear_error() {
 }
 
 #[test]
+fn e2e_plain_flag_and_legacy_tui_alias_both_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("s.bin");
+    fs::write(&src, b"plain-test").unwrap();
+
+    for (flag, tag) in [("--plain", "long"), ("--tui", "alias"), ("-t", "short")] {
+        let dst = dir.path().join(format!("d_{tag}.bin"));
+        let (ok, _stdout, stderr) =
+            run_bcmr(&["copy", flag, src.to_str().unwrap(), dst.to_str().unwrap()]);
+        assert!(ok, "{flag} should be accepted, stderr: {stderr}");
+        assert!(dst.exists(), "{flag} did not produce output");
+    }
+}
+
+#[test]
+fn e2e_help_advertises_plain_not_tui() {
+    let (_ok, stdout, _stderr) = run_bcmr(&["copy", "--help"]);
+    assert!(
+        stdout.contains("--plain"),
+        "expected --plain in help, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--tui"),
+        "did not expect --tui in help (kept as hidden alias), got: {stdout}"
+    );
+}
+
+#[test]
 fn e2e_same_host_remote_to_remote_copy_refuses() {
     let (ok, _stdout, stderr) = run_bcmr(&[
         "copy",


### PR DESCRIPTION
Closes #77.

## Summary

The flag \`-t/--tui\` actually enabled the **plain** inline renderer; *omitting* it selected the fancy TUI box. Every user got the inversion wrong the first time — the help text even said \"Enable inline TUI mode\" while the flag name said \"tui\".

## Fix

Rename the user-facing surface to \`--plain\` (positive-name, matches what it actually does). \`-t\` and \`--tui\` are kept as clap aliases so existing scripts keep working without warning. Internal helper \`is_tui_mode\` -> \`is_plain_progress\` to match the semantics.

\`\`\`
$ bcmr copy --help | grep -E 'plain|tui'
      --plain   Use plain inline progress (3-line) instead of the fancy TUI box

$ bcmr copy --plain src dst    # canonical
$ bcmr copy --tui src dst      # alias (still works)
$ bcmr copy -t src dst         # short alias (still works)
\`\`\`

The aliases are not advertised in \`--help\` but remain accepted; drop them in a future major release.

Internal renames: \`CopyMoveArgs.tui\` -> \`CopyMoveArgs.plain\`, \`Commands::Remove { tui }\` -> \`{ plain }\`, \`Commands::is_tui_mode\` -> \`is_plain_progress\`. Cascade through \`src/commands/remove.rs\` and \`src/commands/remote_copy.rs::is_plain_mode\`.

## Out of scope

\#46 (auto-degrade for non-TTY) and #55 (NO_COLOR) — both already handled in main. This PR does not change auto-detection behaviour, only the explicit-flag spelling.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green (existing tests still use \`-t\`, all pass via alias)
- [x] New tests: \`e2e_plain_flag_and_legacy_tui_alias_both_accepted\` (locks in alias contract for \`--plain\`/\`--tui\`/\`-t\`); \`e2e_help_advertises_plain_not_tui\` (locks help text)
- [x] Live: \`bcmr copy --plain a.txt b.txt\`, \`bcmr copy --tui a.txt b.txt\`, \`bcmr copy -t a.txt b.txt\` all succeed
- [x] Live: \`bcmr copy --help\` shows only \`--plain\`; \`bcmr remove --help\` likewise