### PR TITLE
docs(cli): add EXAMPLES / ENVIRONMENT / EXIT CODES to --help (#74)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,119 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+const CLI_AFTER_LONG_HELP: &str = "\
+EXAMPLES:
+  Copy a file to a remote host:
+      bcmr copy ./report.pdf host:backup/
+
+  Recursive with attribute preservation:
+      bcmr copy -r -p ./project/ host:archives/
+
+  Resume a partial transfer:
+      bcmr copy -C ./large.iso host:backup/
+
+  Background with JSON for scripts:
+      bcmr copy --json -V ./big.tar.gz host:dst/
+
+  Compare source and destination without copying:
+      bcmr check ./project/ host:archives/
+
+ENVIRONMENT:
+  BCMR_CAS_DIR                  CAS directory (default: $XDG_CACHE_HOME/bcmr/cas)
+  BCMR_CAS_CAP_MB               CAS size cap in MB
+  BCMR_DEBUG_SSH_STDERR=1       surface ssh stderr for debugging
+  BCMR_RENDEZVOUS_TIMEOUT_SECS  direct-TCP rendezvous timeout (seconds)
+  BCMR_UNSAFE_LAN_LISTEN=1      opt-in to LAN listen on 'bcmr serve' (requires peer-auth)
+  NO_COLOR                      any non-empty value disables colored output
+  TERM=dumb                     selects plain renderer
+
+CONFIGURATION:
+  ~/.config/bcmr/config.toml      (override with $XDG_CONFIG_HOME)
+
+EXIT CODES:
+  0    success
+  1    transfer error / 'bcmr check' not in sync
+  2    error result in --json mode / SourceNotFound on bare 'bcmr check'
+  64   invalid arguments (clap)
+  130  Ctrl-C / SIGINT
+
+DOCUMENTATION:
+  https://app.snaix.homes/bcmr
+";
+
+const COPY_AFTER_LONG_HELP: &str = "\
+EXAMPLES:
+  Local copy with verify:
+      bcmr copy -V src.iso dst.iso
+
+  Recursive with preserve, parallel local jobs:
+      bcmr copy -r -p -j 4 ./project/ ./backup/
+
+  Upload to remote host:
+      bcmr copy ./report.pdf host:archive/
+
+  Resume a previous run after interruption:
+      bcmr copy -C ./large.tar.gz host:dst/
+
+  Background job with JSON status events:
+      bcmr copy --json -V ./big.bin host:dst/   # query: bcmr status
+
+  Sparse-aware copy:
+      bcmr copy --sparse=auto disk.img dst.img
+
+  Compress wire payload (auto-skips already-compressed files):
+      bcmr copy --compress=auto src/ host:dst/
+";
+
+const MOVE_AFTER_LONG_HELP: &str = "\
+EXAMPLES:
+  Local rename or move (atomic when same filesystem):
+      bcmr move ./old.txt ./new.txt
+
+  Move recursively to a remote host (copy + verify + delete-source):
+      bcmr move -r -V ./project/ host:archive/
+";
+
+const CHECK_AFTER_LONG_HELP: &str = "\
+EXAMPLES:
+  Compare a single local file against a remote one:
+      bcmr check ./report.pdf host:archive/report.pdf
+
+  Recursive directory check (size + content hash for size-matched files):
+      bcmr check -r ./project/ host:archive/
+
+  JSON output for scripts:
+      bcmr check --json ./project/ host:archive/
+
+  Skip content hashing (legacy size+mtime only):
+      bcmr check --no-hash ./project/ host:archive/
+";
+
+const REMOVE_AFTER_LONG_HELP: &str = "\
+EXAMPLES:
+  Remove a file:
+      bcmr remove ./old.log
+
+  Recursive removal with confirmation:
+      bcmr remove -r ./build/
+
+  Force removal (no prompt) and verbose output:
+      bcmr remove -rf -v ./tmp/
+
+  Empty directory only (rmdir-like):
+      bcmr remove -d ./empty-dir/
+
+  Dry-run to preview:
+      bcmr remove -rn ./candidate/
+";
+
 #[derive(Parser, Debug)]
 #[command(
     name = "bcmr",
     about = "Better Copy Move Remove (BCMR) - A modern CLI tool for file operations",
     version,
-    author
+    author,
+    after_long_help = CLI_AFTER_LONG_HELP
 )]
 pub struct Cli {
     #[command(subcommand)]
@@ -163,6 +270,7 @@ pub enum Commands {
     },
 
     /// Copy files or directories
+    #[command(after_long_help = COPY_AFTER_LONG_HELP)]
     Copy {
         #[command(flatten)]
         args: CopyMoveArgs,
@@ -181,6 +289,7 @@ pub enum Commands {
     },
 
     /// Move files or directories
+    #[command(after_long_help = MOVE_AFTER_LONG_HELP)]
     Move {
         #[command(flatten)]
         args: CopyMoveArgs,
@@ -233,6 +342,7 @@ pub enum Commands {
     },
 
     /// Compare source and destination without making changes
+    #[command(after_long_help = CHECK_AFTER_LONG_HELP)]
     Check {
         /// Source files and destination (last argument is the destination)
         #[arg(required = true, num_args = 2..)]
@@ -252,6 +362,7 @@ pub enum Commands {
     },
 
     /// Remove files or directories
+    #[command(after_long_help = REMOVE_AFTER_LONG_HELP)]
     Remove {
         /// Files or directories to remove
         #[arg(required = true)]

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -1008,6 +1008,36 @@ fn e2e_no_deref_remote_target_refuses() {
 }
 
 #[test]
+fn e2e_help_long_form_lists_examples_env_and_exit_codes() {
+    let (_ok, stdout, _stderr) = run_bcmr(&["--help"]);
+    for token in ["EXAMPLES:", "ENVIRONMENT:", "EXIT CODES:", "BCMR_CAS_DIR"] {
+        assert!(
+            stdout.contains(token),
+            "expected '{token}' in --help, got: {stdout}"
+        );
+    }
+
+    let (_ok, short_stdout, _) = run_bcmr(&["-h"]);
+    for token in ["EXAMPLES:", "ENVIRONMENT:", "EXIT CODES:"] {
+        assert!(
+            !short_stdout.contains(token),
+            "did not expect '{token}' in -h short form, got: {short_stdout}"
+        );
+    }
+}
+
+#[test]
+fn e2e_subcommand_help_shows_examples() {
+    for sub in ["copy", "move", "check", "remove"] {
+        let (_ok, stdout, _stderr) = run_bcmr(&[sub, "--help"]);
+        assert!(
+            stdout.contains("EXAMPLES:"),
+            "{sub} --help missing EXAMPLES: section, got: {stdout}"
+        );
+    }
+}
+
+#[test]
 fn e2e_cross_host_copy_refuses_with_clear_error() {
     let (ok, _stdout, stderr) = run_bcmr(&[
         "copy",


### PR DESCRIPTION
Closes #74.

## Summary

\`bcmr --help\` was content-thin: 30 lines, no examples, no env vars, no config-path reference, no exit codes. The five \`BCMR_*\` env vars (\`CAS_DIR\`, \`CAS_CAP_MB\`, \`DEBUG_SSH_STDERR\`, \`RENDEZVOUS_TIMEOUT_SECS\`, \`UNSAFE_LAN_LISTEN\`) were undiscoverable from the binary itself; users had to grep source.

## What changes

Wires clap \`after_long_help\` strings on the root \`Cli\` and on the four operation subcommands (\`copy\`, \`move\`, \`check\`, \`remove\`).

Top-level \`bcmr --help\` now carries:
- **EXAMPLES** — five common invocations.
- **ENVIRONMENT** — all five \`BCMR_*\` vars plus \`NO_COLOR\` and \`TERM=dumb\`.
- **CONFIGURATION** — config-file path with \`$XDG_CONFIG_HOME\` override.
- **EXIT CODES** — 0 / 1 / 2 / 64 / 130.
- **DOCUMENTATION** — link to docs site.

\`bcmr copy --help\`, \`bcmr move --help\`, \`bcmr check --help\`, \`bcmr remove --help\` get their own scoped EXAMPLES sections.

\`-h\` short form stays terse — clap shows \`after_long_help\` only on \`--help\`, with the standard \"(see more with '--help')\" hint on the \`-h\` line.

Strings are module-level \`&str\` consts to keep the enum declarations readable.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] New test \`e2e_help_long_form_lists_examples_env_and_exit_codes\` — locks the EXAMPLES / ENVIRONMENT / EXIT CODES / BCMR_CAS_DIR tokens in long-form, and asserts they're absent in \`-h\` short form.
- [x] New test \`e2e_subcommand_help_shows_examples\` — locks EXAMPLES section on copy/move/check/remove.
- [x] Live: \`bcmr --help\`, \`bcmr -h\`, \`bcmr copy --help\` all render as expected.

## Out of scope

Issue also lists \"\`bcmr -h\` (short) vs \`bcmr --help\` (long)\" — clap's \`after_long_help\` already gives that distinction (\`-h\` skips the rich block, \`--help\` shows it). No further wiring needed for that ask.