### PR TITLE
feat(ui): surface skipped bytes in Done: summary (#76)

### DIFF
--- a/src/ui/inline.rs
+++ b/src/ui/inline.rs
@@ -263,15 +263,8 @@ impl ProgressRenderer for InlineProgress {
     }
 
     fn finish(&mut self) -> io::Result<()> {
-        let elapsed = self.data.elapsed();
-        let avg_bps = self.data.average_bytes_per_sec().unwrap_or(0.0);
         println!();
-        println!(
-            "Done: {} in {:.1}s | avg {}/s",
-            format_bytes(self.data.current_bytes as f64),
-            elapsed.as_secs_f64(),
-            format_bytes(avg_bps)
-        );
+        println!("{}", self.data.done_summary_line());
         Ok(())
     }
 }

--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -2,7 +2,6 @@ use crate::ui::inline::InlineProgress;
 use crate::ui::json::JsonProgress;
 use crate::ui::state::ProgressData;
 use crate::ui::tui::TuiProgress;
-use crate::ui::utils::format_bytes;
 use std::io::{self, IsTerminal};
 use std::path::PathBuf;
 
@@ -59,14 +58,7 @@ impl ProgressRenderer for PlainTextProgress {
     }
 
     fn finish(&mut self) -> io::Result<()> {
-        let elapsed = self.data.elapsed();
-        let avg_bps = self.data.average_bytes_per_sec().unwrap_or(0.0);
-        println!(
-            "Done: {} in {:.1}s | avg {}/s",
-            format_bytes(self.data.current_bytes as f64),
-            elapsed.as_secs_f64(),
-            format_bytes(avg_bps),
-        );
+        println!("{}", self.data.done_summary_line());
         Ok(())
     }
 }

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -179,6 +179,24 @@ impl ProgressData {
         }
         Some(self.current_bytes as f64 / secs)
     }
+
+    pub fn done_summary_line(&self) -> String {
+        use crate::ui::utils::format_bytes;
+        let avg = self.average_bytes_per_sec().unwrap_or(0.0);
+        let mut line = format!(
+            "Done: {} in {:.1}s | avg {}/s",
+            format_bytes(self.current_bytes as f64),
+            self.elapsed().as_secs_f64(),
+            format_bytes(avg),
+        );
+        if self.skipped_bytes > 0 {
+            line.push_str(&format!(
+                " | skipped {}",
+                format_bytes(self.skipped_bytes as f64)
+            ));
+        }
+        line
+    }
 }
 
 #[cfg(test)]
@@ -256,5 +274,27 @@ mod tests {
         w.last_update = Instant::now() - Duration::from_secs(1);
         let speed = w.calculate_speed();
         assert!(speed > 0.0);
+    }
+
+    #[test]
+    fn test_done_summary_omits_skipped_when_zero() {
+        let mut pd = ProgressData::new(1024);
+        pd.current_bytes = 1024;
+        let line = pd.done_summary_line();
+        assert!(line.starts_with("Done:"), "got: {line}");
+        assert!(line.contains("avg"), "got: {line}");
+        assert!(!line.contains("skipped"), "got: {line}");
+    }
+
+    #[test]
+    fn test_done_summary_includes_skipped_when_nonzero() {
+        let mut pd = ProgressData::new(1024 * 1024 * 100);
+        pd.inc_skipped(1024 * 1024 * 30);
+        let line = pd.done_summary_line();
+        assert!(line.contains("skipped"), "got: {line}");
+        assert!(
+            line.contains("30"),
+            "expected skipped MiB count, got: {line}"
+        );
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -583,14 +583,7 @@ impl ProgressRenderer for TuiProgress {
             println!();
         }
 
-        let elapsed = self.data.elapsed();
-        let avg_bps = self.data.average_bytes_per_sec().unwrap_or(0.0);
-        println!(
-            "Done: {} in {:.1}s | avg {}/s",
-            format_bytes(self.data.current_bytes as f64),
-            elapsed.as_secs_f64(),
-            format_bytes(avg_bps)
-        );
+        println!("{}", self.data.done_summary_line());
 
         self.finished = true;
         Ok(())


### PR DESCRIPTION
Partial close of #76 (the cheap counter; the others need new plumbing).

## Summary

The Done line surfaced only transferred bytes, elapsed time, and average speed. \`--append\` / \`--update\` hashed-block-skip already increments \`ProgressData.skipped_bytes\` correctly, but never made it onto the user-visible report — a 100 GB sync where 99 GB already matched looked indistinguishable in stdout from a 100 GB fresh transfer.

## What changes

Adds an opt-in suffix to the Done line, gated on \`skipped_bytes > 0\`:

\`\`\`
# Before / no skip (unchanged):
Done: 100 GiB in 8.2s | avg 12.2 GiB/s

# With --append + 99 GB matched:
Done: 100 GiB in 0.5s | avg 199 GiB/s | skipped 99 GiB
\`\`\`

When nothing was skipped, output is byte-for-byte unchanged — existing parsers and snapshots stay valid.

Factored into \`ProgressData::done_summary_line()\` so all three renderers (\`PlainTextProgress\` in progress.rs, \`InlineProgress\`, \`TuiProgress\`) call one helper. Removes three near-identical \`format!\` blocks.

## Out of scope (intentional)

Issue lists more facts to surface in the Done line: reflink count, dedup ratio, compress ratio, verify-done flag, files-skipped count. Each needs new counters plumbed from the copy backend up to \`ProgressData\` — not a one-line change. \`skipped_bytes\` is the only counter that already exists end-to-end. Remaining facts will land as the underlying signals are wired.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green; 2 new unit tests in \`src/ui/state.rs\` (\`test_done_summary_omits_skipped_when_zero\`, \`test_done_summary_includes_skipped_when_nonzero\`)
- [x] Live: \`bcmr copy -t a.txt b.txt\` (no skip) prints unchanged Done line
- [x] Live: \`bcmr copy -t --append a.txt b.txt\` exercises the wiring (no live TG-skip available locally; remote-side skip path verified by unit test asserting format)