### PR TITLE
feat(status): --rm / --rm --all / --gc on bcmr status (#68)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,6 +317,29 @@ jobs:
           echo "status: $status"
           echo "$status" | grep -q '"type":"result"' || { echo "FAIL: status did not return result"; exit 1; }
 
+          # bcmr status --rm <id> should drop just that job's log.
+          rm_out=$(cargo run --quiet -- --json status "$job_id" --rm)
+          echo "rm: $rm_out"
+          echo "$rm_out" | grep -q '"removed":true' || { echo "FAIL: --rm did not report removed:true"; exit 1; }
+          [ -e "$log" ] && { echo "FAIL: log file still exists after --rm"; exit 1; }
+
+          # bcmr status --gc returns a count (no surviving jobs to GC here).
+          gc_out=$(cargo run --quiet -- --json status --gc)
+          echo "gc: $gc_out"
+          echo "$gc_out" | grep -q '"action":"gc"' || { echo "FAIL: --gc did not report action"; exit 1; }
+
+          # Conflict: --rm + --gc should be rejected by clap.
+          if cargo run --quiet -- status --rm --gc 2>/dev/null; then
+            echo "FAIL: clap should reject --rm + --gc"
+            exit 1
+          fi
+
+          # Conflict: positional id + --all should be rejected by clap.
+          if cargo run --quiet -- status someid --rm --all 2>/dev/null; then
+            echo "FAIL: clap should reject positional id + --all"
+            exit 1
+          fi
+
           echo "--json background mode remove test passed"
 
       - name: Test version and help

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -26,7 +26,60 @@ pub(crate) fn status_detail(latest: &str) -> String {
         .unwrap_or_default()
 }
 
-pub(crate) fn handle_status_command(job_id: &Option<String>) {
+pub(crate) fn handle_status_command(job_id: &Option<String>, rm: bool, all: bool, gc: bool) {
+    if gc {
+        let removed = commands::jobs::cleanup_old_jobs(commands::jobs::DEFAULT_GC_RETENTION_SECS);
+        if is_json_mode() {
+            println!(
+                "{}",
+                serde_json::json!({"action": "gc", "removed": removed})
+            );
+        } else {
+            println!("Removed {} old job log(s).", removed);
+        }
+        return;
+    }
+
+    if rm {
+        if all {
+            let removed = commands::jobs::remove_all_jobs();
+            if is_json_mode() {
+                println!(
+                    "{}",
+                    serde_json::json!({"action": "rm", "scope": "all", "removed": removed})
+                );
+            } else {
+                println!("Removed {} job log(s).", removed);
+            }
+            return;
+        }
+        let Some(id) = job_id else {
+            eprintln!("Error: --rm needs a job id (or pass --all to drop every job)");
+            std::process::exit(2);
+        };
+        match commands::jobs::remove_job(id) {
+            Ok(true) => {
+                if is_json_mode() {
+                    println!(
+                        "{}",
+                        serde_json::json!({"action": "rm", "job_id": id, "removed": true})
+                    );
+                } else {
+                    println!("Removed job '{}'.", id);
+                }
+            }
+            Ok(false) => {
+                eprintln!("Error: job '{}' not found", id);
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("Error: cannot remove '{}': {}", id, e);
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
     match job_id {
         Some(id) => {
             let (state, latest) = match commands::jobs::job_state(id) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -307,6 +307,18 @@ pub enum Commands {
     Status {
         /// Job ID to query (omit to list all jobs)
         job_id: Option<String>,
+
+        /// Remove the named job's log file (use --all to drop every job)
+        #[arg(long)]
+        rm: bool,
+
+        /// With --rm, target every job log
+        #[arg(long, requires = "rm")]
+        all: bool,
+
+        /// Garbage-collect job logs older than the configured retention (7d)
+        #[arg(long, conflicts_with_all = ["rm", "all"])]
+        gc: bool,
     },
 
     /// Check for updates and self-update

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -313,7 +313,7 @@ pub enum Commands {
         rm: bool,
 
         /// With --rm, target every job log
-        #[arg(long, requires = "rm")]
+        #[arg(long, requires = "rm", conflicts_with = "job_id")]
         all: bool,
 
         /// Garbage-collect job logs older than the configured retention (7d)

--- a/src/commands/jobs.rs
+++ b/src/commands/jobs.rs
@@ -184,11 +184,48 @@ pub fn list_jobs() -> Vec<JobEntry> {
     jobs
 }
 
-pub fn cleanup_old_jobs(max_age_secs: u64) {
+pub fn remove_job(job_id: &str) -> std::io::Result<bool> {
+    remove_job_in(&jobs_dir(), job_id)
+}
+
+pub fn remove_all_jobs() -> usize {
+    remove_all_jobs_in(&jobs_dir())
+}
+
+fn remove_job_in(dir: &std::path::Path, job_id: &str) -> std::io::Result<bool> {
+    let path = dir.join(format!("{}.jsonl", job_id));
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+fn remove_all_jobs_in(dir: &std::path::Path) -> usize {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut removed = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.ends_with(".jsonl") {
+            continue;
+        }
+        if std::fs::remove_file(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+pub const DEFAULT_GC_RETENTION_SECS: u64 = 7 * 24 * 3600;
+
+pub fn cleanup_old_jobs(max_age_secs: u64) -> usize {
     let dir = jobs_dir();
     let entries = match std::fs::read_dir(&dir) {
         Ok(e) => e,
-        Err(_) => return,
+        Err(_) => return 0,
     };
 
     let cutoff = SystemTime::now()
@@ -197,6 +234,7 @@ pub fn cleanup_old_jobs(max_age_secs: u64) {
         .as_secs()
         .saturating_sub(max_age_secs);
 
+    let mut removed = 0usize;
     for entry in entries.flatten() {
         if let Ok(meta) = entry.metadata() {
             let mtime = meta
@@ -206,9 +244,40 @@ pub fn cleanup_old_jobs(max_age_secs: u64) {
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
 
-            if mtime < cutoff {
-                let _ = std::fs::remove_file(entry.path());
+            if mtime < cutoff && std::fs::remove_file(entry.path()).is_ok() {
+                removed += 1;
             }
         }
+    }
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_job_in_deletes_existing_log() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("abc.jsonl"), "{}").unwrap();
+        assert!(remove_job_in(dir.path(), "abc").unwrap());
+        assert!(!dir.path().join("abc.jsonl").exists());
+    }
+
+    #[test]
+    fn test_remove_job_in_returns_false_for_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!remove_job_in(dir.path(), "nope").unwrap());
+    }
+
+    #[test]
+    fn test_remove_all_jobs_in_drops_only_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.jsonl"), "{}").unwrap();
+        std::fs::write(dir.path().join("b.jsonl"), "{}").unwrap();
+        std::fs::write(dir.path().join("readme.txt"), "keep").unwrap();
+        let removed = remove_all_jobs_in(dir.path());
+        assert_eq!(removed, 2);
+        assert!(dir.path().join("readme.txt").exists());
     }
 }

--- a/src/commands/jobs.rs
+++ b/src/commands/jobs.rs
@@ -212,8 +212,7 @@ fn remove_all_jobs_in(dir: &std::path::Path) -> usize {
         if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
-        // Skip logs whose owning process is still alive — unlinking the file
-        // mid-write loses any data the writer hadn't fsync'd yet.
+        // Unlinking mid-write loses data the writer hadn't fsync'd yet.
         if job_is_active(&path) {
             continue;
         }
@@ -302,6 +301,7 @@ mod tests {
         assert!(dir.path().join("readme.txt").exists());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_remove_all_jobs_in_skips_active_pid() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/commands/jobs.rs
+++ b/src/commands/jobs.rs
@@ -208,15 +208,36 @@ fn remove_all_jobs_in(dir: &std::path::Path) -> usize {
     };
     let mut removed = 0usize;
     for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if !name.ends_with(".jsonl") {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
             continue;
         }
-        if std::fs::remove_file(entry.path()).is_ok() {
+        // Skip logs whose owning process is still alive — unlinking the file
+        // mid-write loses any data the writer hadn't fsync'd yet.
+        if job_is_active(&path) {
+            continue;
+        }
+        if std::fs::remove_file(&path).is_ok() {
             removed += 1;
         }
     }
     removed
+}
+
+fn job_is_active(log_path: &std::path::Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(log_path) else {
+        return false;
+    };
+    let Some(first) = content.lines().next() else {
+        return false;
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(first) else {
+        return false;
+    };
+    v.get("pid")
+        .and_then(|p| p.as_u64())
+        .map(|p| is_pid_alive(p as u32))
+        .unwrap_or(false)
 }
 
 pub const DEFAULT_GC_RETENTION_SECS: u64 = 7 * 24 * 3600;
@@ -279,5 +300,22 @@ mod tests {
         let removed = remove_all_jobs_in(dir.path());
         assert_eq!(removed, 2);
         assert!(dir.path().join("readme.txt").exists());
+    }
+
+    #[test]
+    fn test_remove_all_jobs_in_skips_active_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let active = dir.path().join("active.jsonl");
+        let stale = dir.path().join("stale.jsonl");
+        std::fs::write(
+            &active,
+            format!("{{\"pid\":{},\"job_id\":\"x\"}}\n", std::process::id()),
+        )
+        .unwrap();
+        std::fs::write(&stale, "{\"pid\":999999,\"job_id\":\"y\"}\n").unwrap();
+        let removed = remove_all_jobs_in(dir.path());
+        assert_eq!(removed, 1);
+        assert!(active.exists(), "active log must survive");
+        assert!(!stale.exists(), "stale log must be removed");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn maybe_detach(cli: &cli::Cli) -> Result<bool> {
 
     println!("{}", serde_json::to_string(&job_info)?);
 
-    commands::jobs::cleanup_old_jobs(7 * 24 * 3600);
+    let _ = commands::jobs::cleanup_old_jobs(commands::jobs::DEFAULT_GC_RETENTION_SECS);
 
     Ok(true)
 }
@@ -119,8 +119,13 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        Commands::Status { job_id } => {
-            handle_status_command(job_id);
+        Commands::Status {
+            job_id,
+            rm,
+            all,
+            gc,
+        } => {
+            handle_status_command(job_id, *rm, *all, *gc);
         }
         Commands::Init { .. } => handle_init_command(&cli.command)?,
         Commands::Update { check } => {


### PR DESCRIPTION
Closes #68 (cleanup half; --kill / --watch / --filter need follow-ups).

## Summary

Background job logs under \`\$XDG_DATA_HOME/bcmr/jobs\` (or macOS \`Library/Application Support/bcmr/jobs\`) accumulated with no user-facing way to clear them. The 7-day GC ran implicitly at every job spawn — on a quiet host that never fires, so logs piled up indefinitely.

## What changes

Three new flags on \`bcmr status\`:

\`\`\`
bcmr status <id> --rm     # drop one job's log
bcmr status --rm --all    # drop every job's log
bcmr status --gc          # explicit GC (>= 7d old)
\`\`\`

Each form mirrors under \`--json\` (\`{action, scope?, job_id?, removed}\`) so scripts can parse the action.

\`\`\`
\$ bcmr status --gc
Removed 4 old job log(s).

\$ bcmr status abc123 --rm
Removed job 'abc123'.

\$ bcmr status --rm --all
Removed 12 job log(s).
\`\`\`

Clap conflicts: \`--gc\` conflicts with \`--rm\` / \`--all\`; \`--all\` requires \`--rm\`.

## Refactor in service of testability

- \`jobs::cleanup_old_jobs\` now returns the count it removed (was \`()\`).
- \`remove_job\` / \`remove_all_jobs\` split into thin public wrappers + dir-parameterized internals (\`remove_job_in\`, \`remove_all_jobs_in\`) so unit tests can target a tempdir instead of the user's real \`\$XDG_DATA_HOME/bcmr/jobs\`.

## Out of scope

Issue #68 also asks for:
- \`--kill <id>\` — needs a real signaling subsystem and a confirm/force gate.
- \`--watch <id>\` — needs follow-tail-and-render plumbing.
- \`--filter <expr>\` — needs a small query lang for status (state, age, host).

Each of those is its own PR with its own design surface; this lands the cleanup half.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green; 3 new unit tests in \`src/commands/jobs.rs\` against tempdirs
- [x] Live: \`bcmr status\` listing unchanged with no flags
- [x] Live: \`bcmr status <id> --rm\` removes one log; \`--rm --all\` clears all; \`--gc\` returns count; \`--rm --gc\` rejected by clap
- [x] Live: \`bcmr status --rm\` (no id, no --all) errors with hint