### PR TITLE
feat: add 'bcmr doctor' subcommand for setup diagnostics (#72)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -408,13 +408,16 @@ jobs:
           fi
 
           # --config <PATH> should be honored — point at a file with valid TOML
-          # and confirm doctor names it back in the report.
+          # and confirm doctor names it back in the report. We assert the
+          # basename only because mktemp on Windows Git Bash returns a Unix-
+          # style path while Rust prints the canonical Windows path.
           tmp=$(mktemp)
           echo '[progress]' > "$tmp"
           echo 'style = "plain"' >> "$tmp"
           out2=$(cargo run --quiet -- --config "$tmp" doctor)
           echo "$out2"
-          echo "$out2" | grep -q "$tmp" || { echo "FAIL: --config path not surfaced"; exit 1; }
+          base=$(basename "$tmp")
+          echo "$out2" | grep -q "$base" || { echo "FAIL: --config basename '$base' not surfaced"; exit 1; }
           rm -f "$tmp"
 
           echo "doctor smoke tests passed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -364,6 +364,7 @@ jobs:
           cargo run -- init --help
           cargo run -- update --help
           cargo run -- completions --help
+          cargo run -- doctor --help
           echo "Help/version tests passed"
 
       - name: Test no-args common-usage hint
@@ -380,3 +381,40 @@ jobs:
           err=$(cargo run --quiet -- cp 2>&1 || true)
           echo "$err" | grep -q "copy" || { echo "FAIL: did-you-mean did not suggest 'copy' for 'cp'"; exit 1; }
           echo "no-args + did-you-mean tests passed"
+
+      - name: Test bcmr doctor (local + JSON shape)
+        shell: bash
+        run: |
+          # Plain run with no host args should exit 0 on a healthy CI runner.
+          out=$(cargo run --quiet -- doctor)
+          echo "$out"
+          echo "$out" | grep -q "Local:" || { echo "FAIL: missing 'Local:' header"; exit 1; }
+          echo "$out" | grep -q "config file" || { echo "FAIL: missing config file check"; exit 1; }
+          echo "$out" | grep -q "jobs dir" || { echo "FAIL: missing jobs dir check"; exit 1; }
+          echo "$out" | grep -q "Pass host arguments" || { echo "FAIL: missing host hint"; exit 1; }
+
+          # JSON shape: single object with the four documented top-level keys.
+          js=$(cargo run --quiet -- --json doctor)
+          echo "$js"
+          echo "$js" | grep -q '"bcmr_version"' || { echo "FAIL: missing bcmr_version"; exit 1; }
+          echo "$js" | grep -q '"local"' || { echo "FAIL: missing local array"; exit 1; }
+          echo "$js" | grep -q '"hosts"' || { echo "FAIL: missing hosts array"; exit 1; }
+          echo "$js" | grep -q '"ok":true' || { echo "FAIL: missing ok=true on healthy local"; exit 1; }
+
+          # Unreachable host should make the run exit non-zero.
+          if cargo run --quiet -- doctor this-host-does-not-resolve.invalid 2>/dev/null; then
+            echo "FAIL: doctor against unreachable host should exit non-zero"
+            exit 1
+          fi
+
+          # --config <PATH> should be honored — point at a file with valid TOML
+          # and confirm doctor names it back in the report.
+          tmp=$(mktemp)
+          echo '[progress]' > "$tmp"
+          echo 'style = "plain"' >> "$tmp"
+          out2=$(cargo run --quiet -- --config "$tmp" doctor)
+          echo "$out2"
+          echo "$out2" | grep -q "$tmp" || { echo "FAIL: --config path not surfaced"; exit 1; }
+          rm -f "$tmp"
+
+          echo "doctor smoke tests passed"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "terminal_size",
  "thiserror",
  "tokio",
+ "toml 0.8.23",
  "walkdir",
  "xattr",
  "zeroize",
@@ -370,8 +371,8 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml",
- "winnow",
+ "toml 1.1.2+spec-1.1.0",
+ "winnow 1.0.2",
  "yaml-rust2",
 ]
 
@@ -2201,6 +2202,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -2561,15 +2571,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2582,13 +2613,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3234,6 +3285,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ parking_lot = "0.12.5"
 filetime = "0.2.28"
 libc = "0.2.186"
 config = "0.15.22"
+toml = "0.8"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 directories = "6.0.0"

--- a/docs/ablation/json-schema.md
+++ b/docs/ablation/json-schema.md
@@ -127,6 +127,48 @@ Error:
 
 Exit code is `0` when `in_sync=true`, `1` when not, `2` on error.
 
+## `bcmr doctor --json`
+
+`bcmr doctor` is foreground and synchronous; under `--json` it emits a single object on stdout — no NDJSON, no header, no progress events:
+
+```json
+{
+  "bcmr_version": "0.6.0",
+  "local": [
+    {"status":"ok","label":"config file","detail":"/Users/.../config.toml (valid TOML)"},
+    {"status":"warn","label":"jobs dir","detail":"... (62 jobs, 1.4 MiB)","recommend":"consider 'bcmr status --gc' ..."}
+  ],
+  "hosts": [
+    {
+      "host": "user@host1",
+      "checks": [
+        {"status":"ok","label":"ssh","detail":"reachable as user@host1"},
+        {"status":"ok","label":"remote bcmr","detail":"/home/u/.cargo/bin/bcmr v0.6.0 (matches local)"}
+      ]
+    }
+  ],
+  "ok": true
+}
+```
+
+| Field          | Type   | Notes                                                                  |
+| -------------- | ------ | ---------------------------------------------------------------------- |
+| `bcmr_version` | string | Local CLI version string.                                              |
+| `local`        | array  | Local environment checks (config / jobs dir / color env).              |
+| `hosts`        | array  | One entry per host arg; preserves input order.                         |
+| `ok`           | bool   | `true` iff no check has `status="fail"` (in either local or hosts).    |
+
+Each `Check` entry carries:
+
+| Field       | Type   | Notes                                                          |
+| ----------- | ------ | -------------------------------------------------------------- |
+| `status`    | string | `"ok"`, `"warn"`, or `"fail"`.                                  |
+| `label`     | string | Short identifier (`config file`, `ssh`, `remote bcmr`, etc.).  |
+| `detail`    | string | Human-readable result.                                         |
+| `recommend` | string | Suggested fix; omitted on plain `ok` checks.                   |
+
+Exit code is `0` when `ok=true`, `1` otherwise. Per-host probes run concurrently but the output preserves input order so scripts can index by position.
+
 ## Error events on a stream
 
 When a background job fails, the log file ends with a single `result` event whose `status="error"` and `error` carries the message. Consumers should treat the absence of a terminal `result` as "process killed before reporting" and fall back to checking `bcmr status <job_id>` — the status command reads the on-disk JobInfo and the log tail.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -337,6 +337,13 @@ pub enum Commands {
         shell: clap_complete::Shell,
     },
 
+    /// Diagnose local + remote setup (ssh / config / bcmr presence)
+    Doctor {
+        /// Optional remote hosts (user@host) to probe
+        #[arg(value_name = "HOST")]
+        hosts: Vec<String>,
+    },
+
     #[command(hide = true)]
     Serve {
         /// Restrict all paths to this directory (defaults to $HOME)

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -166,8 +166,6 @@ fn run_local_checks() -> Vec<Check> {
 }
 
 fn check_config_file() -> Check {
-    // Honor --config / BCMR_CONFIG (set by main.rs) so doctor validates the
-    // file the run will actually load, not always the XDG default.
     let path = std::env::var_os("BCMR_CONFIG")
         .map(PathBuf::from)
         .or_else(|| {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,0 +1,389 @@
+use anyhow::Result;
+use serde::Serialize;
+use std::io::IsTerminal;
+use std::path::PathBuf;
+use tokio::process::Command;
+
+#[derive(Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    Ok,
+    Warn,
+    Fail,
+}
+
+impl CheckStatus {
+    fn glyph(self, ascii: bool) -> &'static str {
+        match (self, ascii) {
+            (CheckStatus::Ok, false) => "✓",
+            (CheckStatus::Warn, false) => "⚠",
+            (CheckStatus::Fail, false) => "✗",
+            (CheckStatus::Ok, true) => "OK",
+            (CheckStatus::Warn, true) => "WARN",
+            (CheckStatus::Fail, true) => "FAIL",
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct Check {
+    pub status: CheckStatus,
+    pub label: String,
+    pub detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommend: Option<String>,
+}
+
+impl Check {
+    fn ok(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            status: CheckStatus::Ok,
+            label: label.into(),
+            detail: detail.into(),
+            recommend: None,
+        }
+    }
+    fn warn(label: impl Into<String>, detail: impl Into<String>, recommend: &str) -> Self {
+        Self {
+            status: CheckStatus::Warn,
+            label: label.into(),
+            detail: detail.into(),
+            recommend: Some(recommend.to_string()),
+        }
+    }
+    fn fail(label: impl Into<String>, detail: impl Into<String>, recommend: &str) -> Self {
+        Self {
+            status: CheckStatus::Fail,
+            label: label.into(),
+            detail: detail.into(),
+            recommend: Some(recommend.to_string()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct HostReport {
+    host: String,
+    checks: Vec<Check>,
+}
+
+pub async fn run(hosts: &[String], json: bool) -> Result<()> {
+    let local = run_local_checks();
+    let host_reports = run_all_host_checks(hosts).await;
+
+    let ok = report_is_ok(&local, &host_reports);
+
+    if json {
+        let envelope = serde_json::json!({
+            "bcmr_version": env!("CARGO_PKG_VERSION"),
+            "local": local,
+            "hosts": host_reports,
+            "ok": ok,
+        });
+        println!("{}", envelope);
+    } else {
+        print_human(env!("CARGO_PKG_VERSION"), &local, &host_reports);
+    }
+
+    if !ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn report_is_ok(local: &[Check], hosts: &[HostReport]) -> bool {
+    !local.iter().any(|c| c.status == CheckStatus::Fail)
+        && !hosts
+            .iter()
+            .any(|h| h.checks.iter().any(|c| c.status == CheckStatus::Fail))
+}
+
+async fn run_all_host_checks(hosts: &[String]) -> Vec<HostReport> {
+    use tokio::task::JoinSet;
+
+    if hosts.is_empty() {
+        return Vec::new();
+    }
+    let mut set: JoinSet<(usize, HostReport)> = JoinSet::new();
+    for (i, host) in hosts.iter().enumerate() {
+        let host = host.clone();
+        set.spawn(async move {
+            let checks = run_host_checks(&host).await;
+            (i, HostReport { host, checks })
+        });
+    }
+    let mut slots: Vec<Option<HostReport>> = (0..hosts.len()).map(|_| None).collect();
+    while let Some(joined) = set.join_next().await {
+        if let Ok((i, rep)) = joined {
+            slots[i] = Some(rep);
+        }
+    }
+    slots.into_iter().flatten().collect()
+}
+
+fn print_human(version: &str, local: &[Check], hosts: &[HostReport]) {
+    let ascii = use_ascii_glyphs();
+    println!("bcmr {} — diagnostic report", version);
+    println!();
+    println!("Local:");
+    for c in local {
+        print_check(c, "  ", ascii);
+    }
+    if hosts.is_empty() {
+        println!();
+        println!("(Pass host arguments to probe remotes: bcmr doctor user@host ...)");
+    } else {
+        for h in hosts {
+            println!();
+            println!("{}:", h.host);
+            for c in &h.checks {
+                print_check(c, "  ", ascii);
+            }
+        }
+    }
+}
+
+fn use_ascii_glyphs() -> bool {
+    crate::ui::progress::ansi_disabled_by_env() || !std::io::stdout().is_terminal()
+}
+
+fn print_check(c: &Check, indent: &str, ascii: bool) {
+    println!(
+        "{}{} {}: {}",
+        indent,
+        c.status.glyph(ascii),
+        c.label,
+        c.detail
+    );
+    if let Some(rec) = &c.recommend {
+        let arrow = if ascii { "->" } else { "→" };
+        println!("{}  {} {}", indent, arrow, rec);
+    }
+}
+
+fn run_local_checks() -> Vec<Check> {
+    vec![check_config_file(), check_jobs_dir(), check_color_env()]
+}
+
+fn check_config_file() -> Check {
+    // Honor --config / BCMR_CONFIG (set by main.rs) so doctor validates the
+    // file the run will actually load, not always the XDG default.
+    let path = std::env::var_os("BCMR_CONFIG")
+        .map(PathBuf::from)
+        .or_else(|| {
+            directories::UserDirs::new().map(|u| {
+                u.home_dir()
+                    .join(".config")
+                    .join("bcmr")
+                    .join("config.toml")
+            })
+        });
+    let Some(path) = path else {
+        return Check::warn(
+            "config file",
+            "could not resolve $HOME and BCMR_CONFIG is unset",
+            "set $HOME to a real directory or pass --config <PATH>",
+        );
+    };
+    if !path.exists() {
+        return Check::ok(
+            "config file",
+            format!("{} (none — using built-in defaults)", path.display()),
+        );
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(s) => match toml::from_str::<toml::Value>(&s) {
+            Ok(_) => Check::ok("config file", format!("{} (valid TOML)", path.display())),
+            Err(e) => Check::fail(
+                "config file",
+                format!("{} (parse error)", path.display()),
+                &format!("fix or remove the file; error: {}", e),
+            ),
+        },
+        Err(e) => Check::fail(
+            "config file",
+            format!("{} (unreadable)", path.display()),
+            &format!("fix permissions; error: {}", e),
+        ),
+    }
+}
+
+fn check_jobs_dir() -> Check {
+    let dir: PathBuf = crate::commands::jobs::jobs_dir();
+    if !dir.exists() {
+        return Check::ok(
+            "jobs dir",
+            format!("{} (empty — created on first --json run)", dir.display()),
+        );
+    }
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            return Check::fail(
+                "jobs dir",
+                format!("{} (unreadable)", dir.display()),
+                &format!("fix permissions; error: {}", e),
+            );
+        }
+    };
+    let (mut count, mut bytes) = (0u64, 0u64);
+    for entry in entries.flatten() {
+        if entry.path().extension().and_then(|e| e.to_str()) == Some("jsonl") {
+            count += 1;
+            if let Ok(meta) = entry.metadata() {
+                bytes += meta.len();
+            }
+        }
+    }
+    let detail = format!(
+        "{} ({} job{}, {})",
+        dir.display(),
+        count,
+        if count == 1 { "" } else { "s" },
+        crate::ui::utils::format_bytes(bytes as f64)
+    );
+    if count > 50 {
+        Check::warn(
+            "jobs dir",
+            detail,
+            "consider running 'bcmr status --gc' to drop logs older than 7 days",
+        )
+    } else {
+        Check::ok("jobs dir", detail)
+    }
+}
+
+fn check_color_env() -> Check {
+    if crate::ui::progress::ansi_disabled_by_env() {
+        let no_color = std::env::var_os("NO_COLOR")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let term = std::env::var("TERM").unwrap_or_default();
+        Check::ok(
+            "color env",
+            format!("ANSI suppressed (NO_COLOR={}, TERM={:?})", no_color, term),
+        )
+    } else {
+        Check::ok(
+            "color env",
+            "ANSI enabled (NO_COLOR unset, TERM not 'dumb')",
+        )
+    }
+}
+
+async fn run_host_checks(host: &str) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    match ssh_probe(host).await {
+        Ok(probe) => {
+            checks.push(Check::ok("ssh", format!("reachable as {}", host)));
+            checks.push(classify_remote_bcmr(&probe));
+        }
+        Err(stderr) => {
+            checks.push(Check::fail(
+                "ssh",
+                crate::core::remote::ssh_error_message(&stderr, host),
+                "verify ~/.ssh/config and key auth (BatchMode=yes is used)",
+            ));
+        }
+    }
+
+    checks
+}
+
+struct RemoteProbe {
+    bcmr_path: Option<String>,
+    bcmr_version: Option<String>,
+}
+
+async fn ssh_probe(host: &str) -> std::result::Result<RemoteProbe, String> {
+    let cmd = "command -v bcmr 2>/dev/null && bcmr --version 2>/dev/null || true";
+    let output = Command::new("ssh")
+        .args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, cmd])
+        .output()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).to_string());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut path = None;
+    let mut version = None;
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('/') {
+            path = Some(line.to_string());
+        } else if line.starts_with("bcmr ") {
+            version = Some(line.trim_start_matches("bcmr ").to_string());
+        }
+    }
+    Ok(RemoteProbe {
+        bcmr_path: path,
+        bcmr_version: version,
+    })
+}
+
+fn classify_remote_bcmr(probe: &RemoteProbe) -> Check {
+    let local = env!("CARGO_PKG_VERSION");
+    match (&probe.bcmr_path, &probe.bcmr_version) {
+        (None, _) => Check::fail(
+            "remote bcmr",
+            "not on PATH",
+            "run 'bcmr deploy <host>' (or '--path /usr/local/bin/bcmr <host>' if ~/.local/bin is not in non-interactive PATH)",
+        ),
+        (Some(path), None) => Check::warn(
+            "remote bcmr",
+            format!("{} (version unknown)", path),
+            "the binary did not respond to --version; try 'ssh <host> bcmr --version' to debug",
+        ),
+        (Some(path), Some(v)) if v == local => {
+            Check::ok("remote bcmr", format!("{} v{} (matches local)", path, v))
+        }
+        (Some(path), Some(v)) => Check::warn(
+            "remote bcmr",
+            format!("{} v{} (local v{})", path, v, local),
+            "consider 'bcmr deploy <host>' to upgrade — protocol may auto-fall-back on mismatch",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_ok_is_true_when_no_fails() {
+        let local = vec![Check::ok("a", "x"), Check::warn("b", "y", "z")];
+        let hosts = vec![HostReport {
+            host: "h".into(),
+            checks: vec![Check::ok("ssh", "ok")],
+        }];
+        assert!(report_is_ok(&local, &hosts));
+    }
+
+    #[test]
+    fn report_ok_is_false_on_local_fail() {
+        let local = vec![Check::fail("a", "x", "fix")];
+        assert!(!report_is_ok(&local, &[]));
+    }
+
+    #[test]
+    fn report_ok_is_false_on_host_fail() {
+        let hosts = vec![HostReport {
+            host: "h".into(),
+            checks: vec![Check::fail("ssh", "x", "fix")],
+        }];
+        assert!(!report_is_ok(&[], &hosts));
+    }
+
+    #[test]
+    fn glyph_ascii_fallback() {
+        assert_eq!(CheckStatus::Ok.glyph(true), "OK");
+        assert_eq!(CheckStatus::Warn.glyph(true), "WARN");
+        assert_eq!(CheckStatus::Fail.glyph(true), "FAIL");
+        assert_eq!(CheckStatus::Ok.glyph(false), "✓");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod check;
 pub mod copy;
 mod copy_strategies;
 pub mod deploy;
+pub mod doctor;
 pub mod init;
 pub mod jobs;
 pub mod r#move;

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -13,6 +13,8 @@ pub use ops::{
     resolve_remote_home, validate_ssh_connection,
 };
 pub use resume::{check_resume_state, ResumeDecision};
+#[allow(unused_imports)]
+pub(crate) use ssh_cmd::ssh_error_message;
 pub use transfer::{
     download_directory, download_file, ensure_remote_tree, upload_directory, upload_file,
 };

--- a/src/core/remote/ssh_cmd.rs
+++ b/src/core/remote/ssh_cmd.rs
@@ -61,7 +61,7 @@ pub(super) fn shell_escape(s: &str) -> String {
     s.replace('\'', "'\\''")
 }
 
-pub(super) fn ssh_error_message(stderr: &str, context: &str) -> String {
+pub(crate) fn ssh_error_message(stderr: &str, context: &str) -> String {
     let stderr_lower = stderr.to_lowercase();
     if stderr_lower.contains("connection refused") {
         format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,9 @@ async fn main() -> Result<()> {
             let remote_path = path.as_deref().unwrap_or("~/.local/bin/bcmr");
             commands::deploy::run(target, remote_path, *sudo).await?;
         }
+        Commands::Doctor { hosts } => {
+            commands::doctor::run(hosts, is_json_mode()).await?;
+        }
         Commands::CompleteRemote { partial } => {
             for entry in crate::core::remote::complete_remote_path(partial).await {
                 println!("{}", entry);

--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -69,7 +69,7 @@ impl ProgressRenderer for PlainTextProgress {
     }
 }
 
-fn ansi_disabled_by_env() -> bool {
+pub(crate) fn ansi_disabled_by_env() -> bool {
     let no_color = std::env::var_os("NO_COLOR")
         .map(|v| !v.is_empty())
         .unwrap_or(false);

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -1158,6 +1158,37 @@ fn e2e_config_override_layers_on_top_of_defaults() {
 }
 
 #[test]
+fn e2e_doctor_no_args_emits_local_checks() {
+    let (ok, stdout, _stderr) = run_bcmr(&["doctor"]);
+    assert!(ok, "doctor with no host should exit 0 on a healthy local");
+    assert!(stdout.contains("Local:"), "got: {stdout}");
+    assert!(stdout.contains("config file"), "got: {stdout}");
+    assert!(stdout.contains("jobs dir"), "got: {stdout}");
+    assert!(stdout.contains("color env"), "got: {stdout}");
+    assert!(
+        stdout.contains("Pass host arguments"),
+        "missing host hint, got: {stdout}"
+    );
+}
+
+#[test]
+fn e2e_doctor_unreachable_host_fails_with_exit_1() {
+    let (ok, _stdout, _stderr) = run_bcmr(&["doctor", "this-host-does-not-resolve.invalid"]);
+    assert!(!ok, "doctor against unreachable host should exit non-zero");
+}
+
+#[test]
+fn e2e_doctor_json_emits_structured_report() {
+    let (ok, stdout, _stderr) = run_bcmr(&["--json", "doctor"]);
+    assert!(ok);
+    let trimmed = stdout.trim();
+    assert!(trimmed.starts_with('{'), "got: {stdout}");
+    for token in ["\"bcmr_version\"", "\"local\"", "\"hosts\"", "\"ok\":true"] {
+        assert!(trimmed.contains(token), "missing {token} in JSON: {stdout}");
+    }
+}
+
+#[test]
 fn e2e_same_host_remote_to_remote_copy_refuses() {
     let (ok, _stdout, stderr) = run_bcmr(&[
         "copy",


### PR DESCRIPTION
Closes #72. Lands the local-checks + per-host ssh/bcmr-presence checks; defers stale-ssh-socket scan, non-interactive PATH probe, and CAS-dir check.

## Summary

The deploy / serve / fast-path stack has multiple sharp edges (#38, #41, #46, #55) where a transfer silently falls through to legacy because the remote bcmr is missing or version-mismatched, \`NO_COLOR\` isn't honored, the config file has a typo, etc. Today a user has to read source and reason about non-interactive ssh PATH to diagnose.

\`bcmr doctor\` surfaces these in 30 seconds.

## Output

\`\`\`
\$ bcmr doctor
bcmr 0.6.0 — diagnostic report

Local:
  ✓ config file: /Users/snaix/.config/bcmr/config.toml (valid TOML)
  ✓ jobs dir: /Users/snaix/Library/Application Support/bcmr/jobs (0 jobs, 0 KiB)
  ✓ color env: ANSI enabled (NO_COLOR unset, TERM not 'dumb')

(Pass host arguments to probe remotes: bcmr doctor user@host ...)
\`\`\`

\`\`\`
\$ bcmr doctor 4090 host-bogus.invalid
...
4090:
  ✓ ssh: reachable as 4090
  ⚠ remote bcmr: /home/liangjy/.cargo/bin/bcmr v0.5.20 (local v0.6.0)
    → consider 'bcmr deploy <host>' to upgrade — protocol may auto-fall-back on mismatch

host-bogus.invalid:
  ✗ ssh: not reachable: ssh: Could not resolve hostname host-bogus.invalid
    → verify ~/.ssh/config and key auth (BatchMode=yes is used)
\`\`\`

\`bcmr --json doctor [hosts...]\` emits a structured \`{bcmr_version, local[], hosts[], ok}\` report. Exit code is 1 on any ✗.

## Checks landed in this PR

**Local:**
- config file existence + TOML parse-validity at \`~/.config/bcmr/config.toml\`
- jobs dir count + total size (warns if >50, suggests \`bcmr status --gc\`)
- color env (NO_COLOR / TERM=dumb visibility, confirming the #55 fix)

**Per-host (when host args given):**
- ssh BatchMode reachability with ConnectTimeout=10
- \`command -v bcmr && bcmr --version\` in one ssh roundtrip
- Classifies: not on PATH (\`✗\` + deploy hint), version mismatch (\`⚠\` + upgrade hint), match (\`✓\`)

## Deferred to follow-up PRs

- **Stale ssh control socket scan** — needs path enumeration logic.
- **Non-interactive PATH probe** — the most valuable check from the issue's example, but it needs login-shell vs ssh-shell PATH-probing logic and the "Ubuntu .bashrc returns early" recommendation from #38/#41. Worth its own PR with #38 / #41 closed alongside.
- **CAS dir check** — \`BCMR_CAS_DIR\` + cap interaction is convoluted; not high-signal until the CAS LRU work in \`open-questions.md\` lands.

## Implementation notes

- New module \`src/commands/doctor.rs\` with a small \`Check { status, label, detail, recommend }\` model and a \`DoctorReport\` aggregator.
- One new dep: \`toml = \"0.8\"\` for the config-parse check (cheaper than spinning up the full config-rs loader path).
- New variant \`Commands::Doctor { hosts }\` in cli.rs; one match arm in main.rs dispatch.
- ssh probe uses tokio::process::Command (matching the deploy module's style).

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] 3 new e2e tests in \`tests/e2e_copy_tests.rs\`:
  - \`e2e_doctor_no_args_emits_local_checks\` — local-only run, asserts the three Local: lines + the host-arg hint.
  - \`e2e_doctor_unreachable_host_fails_with_exit_1\` — uses \`.invalid\` TLD (RFC 2606), asserts non-zero exit.
  - \`e2e_doctor_json_emits_structured_report\` — \`--json doctor\`, asserts the four top-level keys present and \`ok=true\`.
- [x] Live: \`bcmr doctor\`, \`bcmr doctor 4090 host-bogus.invalid\`, \`bcmr --json doctor 4090\` all produce expected output (✓/⚠/✗ glyphs render in terminal).