### PR TITLE
feat(cli): add -q/--quiet and --config <PATH> overrides (#78)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -213,7 +213,7 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
             "Copying",
             first_display.as_deref(),
             plan.total_size,
-            false,
+            args.is_quiet(),
         )?;
 
         let result = commands::copy::execute_plan(
@@ -233,7 +233,7 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
         let runner = ProgressRunner::new(
             0,
             is_plain_mode(args),
-            false,
+            args.is_quiet(),
             is_json_mode(),
             commands::copy::cleanup_partial_files,
         )?;
@@ -386,7 +386,7 @@ pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
         "Moving",
         first_display.as_deref(),
         total_size,
-        false,
+        args.is_quiet(),
     )?;
 
     for src in sources {
@@ -609,7 +609,7 @@ pub(crate) async fn handle_remove_command(args: &Commands) -> Result<()> {
         "Removing",
         first_display.as_deref(),
         total_size,
-        false,
+        args.is_quiet(),
     )?;
 
     let result = commands::remove::remove_paths(

--- a/src/app/runners.rs
+++ b/src/app/runners.rs
@@ -16,7 +16,7 @@ pub(crate) fn start_scanning_runner(
     let runner = ProgressRunner::new(
         0,
         is_plain_mode(args),
-        false,
+        args.is_quiet(),
         true,
         commands::copy::cleanup_partial_files,
     )?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Use this config file instead of ~/.config/bcmr/config.toml (layered on top of defaults)
+    #[arg(long, global = true, value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
     #[arg(long = "_bg", hide = true)]
     pub _bg: Option<String>,
 }
@@ -186,6 +190,10 @@ pub struct CopyMoveArgs {
     /// Use plain inline progress (3-line) instead of the fancy TUI box
     #[arg(long, alias = "tui", short_alias = 't')]
     pub plain: bool,
+
+    /// Suppress progress UI; only errors print to stderr
+    #[arg(short = 'q', long)]
+    pub quiet: bool,
 
     /// Run in dry-run mode (no changes)
     #[arg(short = 'n', long)]
@@ -400,6 +408,10 @@ pub enum Commands {
         #[arg(long, alias = "tui", short_alias = 't')]
         plain: bool,
 
+        /// Suppress progress UI; only errors print to stderr
+        #[arg(short = 'q', long)]
+        quiet: bool,
+
         /// Run in dry-run mode (no changes)
         #[arg(short = 'n', long)]
         dry_run: bool,
@@ -465,6 +477,11 @@ impl Commands {
     pub fn is_plain_progress(&self) -> bool {
         self.copy_move_args().is_some_and(|a| a.plain)
             || matches!(self, Commands::Remove { plain: true, .. })
+    }
+
+    pub fn is_quiet(&self) -> bool {
+        self.copy_move_args().is_some_and(|a| a.quiet)
+            || matches!(self, Commands::Remove { quiet: true, .. })
     }
 
     pub fn is_dry_run(&self) -> bool {
@@ -686,6 +703,7 @@ mod tests {
             verbose: false,
             exclude: None,
             plain: false,
+            quiet: false,
             dry_run: false,
             test_mode: None,
             verify: false,
@@ -769,6 +787,7 @@ mod tests {
             dir: true,
             exclude: None,
             plain: false,
+            quiet: false,
             dry_run: false,
             test_mode: None,
         };

--- a/src/commands/remote_copy/legacy.rs
+++ b/src/commands/remote_copy/legacy.rs
@@ -65,7 +65,7 @@ pub(super) async fn handle_remote_upload(
     let runner = ProgressRunner::new(
         total_size,
         is_plain_mode(args),
-        false,
+        args.is_quiet(),
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;
@@ -201,7 +201,7 @@ pub(super) async fn handle_remote_download(
     let runner = ProgressRunner::new(
         total_size,
         is_plain_mode(args),
-        false,
+        args.is_quiet(),
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;

--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -117,7 +117,7 @@ pub(super) async fn handle_serve_upload(
     let runner = ProgressRunner::new(
         total_size,
         is_plain_mode(args),
-        false,
+        args.is_quiet(),
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;
@@ -412,7 +412,7 @@ pub(super) async fn handle_serve_download(
     let runner = ProgressRunner::new(
         total_size,
         is_plain_mode(args),
-        false,
+        args.is_quiet(),
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,6 +260,13 @@ impl Config {
             }
         }
 
+        if let Ok(override_path) = std::env::var("BCMR_CONFIG") {
+            let path = std::path::PathBuf::from(&override_path);
+            if path.exists() {
+                s = s.add_source(File::from(path));
+            }
+        }
+
         s.build()?.try_deserialize()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ fn maybe_detach(cli: &cli::Cli) -> Result<bool> {
 async fn main() -> Result<()> {
     let cli = cli::parse_args();
 
+    if let Some(ref path) = cli.config {
+        std::env::set_var("BCMR_CONFIG", path);
+    }
+
     if maybe_detach(&cli)? {
         return Ok(());
     }

--- a/tests/e2e_copy_tests.rs
+++ b/tests/e2e_copy_tests.rs
@@ -1082,6 +1082,82 @@ fn e2e_help_advertises_plain_not_tui() {
 }
 
 #[test]
+fn e2e_quiet_suppresses_done_line() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("s.bin");
+    let dst = dir.path().join("d.bin");
+    fs::write(&src, b"quiet-test").unwrap();
+
+    let (ok, stdout, _stderr) =
+        run_bcmr(&["copy", "-q", src.to_str().unwrap(), dst.to_str().unwrap()]);
+    assert!(ok, "copy should succeed");
+    assert!(dst.exists(), "dst should exist");
+    assert!(
+        !stdout.contains("Done:"),
+        "expected no Done line under -q, got: {stdout}"
+    );
+}
+
+#[test]
+fn e2e_quiet_long_form_also_suppresses() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("s.bin");
+    let dst = dir.path().join("d.bin");
+    fs::write(&src, b"quiet-long").unwrap();
+
+    let (ok, stdout, _stderr) = run_bcmr(&[
+        "copy",
+        "--quiet",
+        src.to_str().unwrap(),
+        dst.to_str().unwrap(),
+    ]);
+    assert!(ok);
+    assert!(dst.exists());
+    assert!(!stdout.contains("Done:"), "got: {stdout}");
+}
+
+#[test]
+fn e2e_config_override_does_not_crash_on_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("s.bin");
+    let dst = dir.path().join("d.bin");
+    fs::write(&src, b"x").unwrap();
+
+    let (ok, _stdout, _stderr) = run_bcmr(&[
+        "--config",
+        "/nonexistent/bcmr-test.toml",
+        "copy",
+        "-q",
+        src.to_str().unwrap(),
+        dst.to_str().unwrap(),
+    ]);
+    assert!(ok, "missing config path should not break the command");
+    assert!(dst.exists());
+}
+
+#[test]
+fn e2e_config_override_layers_on_top_of_defaults() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = dir.path().join("override.toml");
+    fs::write(&cfg, "[progress]\nstyle = \"plain\"\n").unwrap();
+
+    let src = dir.path().join("s.bin");
+    let dst = dir.path().join("d.bin");
+    fs::write(&src, b"y").unwrap();
+
+    let (ok, _stdout, _stderr) = run_bcmr(&[
+        "--config",
+        cfg.to_str().unwrap(),
+        "copy",
+        "-q",
+        src.to_str().unwrap(),
+        dst.to_str().unwrap(),
+    ]);
+    assert!(ok, "override config should be honored");
+    assert!(dst.exists());
+}
+
+#[test]
 fn e2e_same_host_remote_to_remote_copy_refuses() {
     let (ok, _stdout, stderr) = run_bcmr(&[
         "copy",


### PR DESCRIPTION
Closes #78.

## Summary

Two missing-but-expected CLI conveniences:

1. **\`-q/--quiet\`** — the standard across cp/scp/rsync/cargo for as long as those tools have existed. bcmr shipped a \`SilentProgress\` renderer internally but with no flag to reach it; the workaround was \`> /dev/null 2>&1\` which also kills errors.
2. **\`--config <PATH>\`** — needed for per-project profiles, CI runs that don't share the developer's \`\$XDG_CONFIG_HOME\`, and exercising config knobs in tests without polluting the user's real config.

## What changes

### \`-q/--quiet\` on copy/move/remove

Wires the existing \`SilentProgress\` renderer to a CLI flag at every \`ProgressRunner\` construction site (copy/move local, copy/move remote serve & legacy, remove). Composes with \`--json\` (json takes precedence; \`-q\` is a no-op there).

\`\`\`
\$ bcmr copy a.txt b.txt          # baseline (Done line printed)
Done: 6 B in 0.0s | avg 2.20 KiB/s

\$ bcmr copy -q a.txt b.txt        # -q (no Done line; errors still on stderr)
\`\`\`

### \`--config <PATH>\` as a global flag

\`main.rs\` sets \`BCMR_CONFIG=<path>\` in the env before any \`CONFIG\` access; \`Config::new\` appends the file as the highest-priority source after the default \`~/.config/bcmr/\` paths.

Precedence (matches git):
\`\`\`
defaults < \$XDG_CONFIG_HOME/bcmr/config.toml < \$BCMR_CONFIG / --config
\`\`\`

Missing paths are silently ignored — keeps CI scripts that conditionally point at a config from breaking when the file isn't there yet.

\`\`\`
\$ cat /tmp/p.toml
[progress]
style = \"plain\"

\$ bcmr --config /tmp/p.toml copy src dst    # plain renderer used regardless of TUI default
\`\`\`

## Out of scope

Issue mentions \`-q\` should imply summary-to-stderr-only. Today \`-q\` removes the progress UI entirely (per SilentProgress); errors still surface on stderr unchanged. Routing the per-file summary line to stderr is a separate \`SilentProgress::finish\` change worth its own discussion (we may want a \`-Q\` for true silence vs \`-q\` for stderr-summary). Not in this PR.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] 4 new e2e tests in \`tests/e2e_copy_tests.rs\`:
  - \`e2e_quiet_suppresses_done_line\` (\`-q\` short)
  - \`e2e_quiet_long_form_also_suppresses\` (\`--quiet\`)
  - \`e2e_config_override_does_not_crash_on_missing\` (graceful when path doesn't exist)
  - \`e2e_config_override_layers_on_top_of_defaults\` (real config layered)
- [x] Live: \`bcmr copy -q a b\` produces no progress; \`bcmr copy --quiet a b\` same; \`bcmr --config /nope.toml copy ...\` doesn't crash; \`bcmr --config valid.toml copy ...\` honors override