### PR TITLE
feat(completions): one-shot install / uninstall (#75)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,49 @@ jobs:
           cargo run -- completions powershell > /dev/null
           echo "All completion scripts generated successfully"
 
+      - name: Test completions install / uninstall (POSIX shells)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          export HOME=$(mktemp -d)
+
+          # --print should NOT write the file.
+          path=$(cargo run --quiet -- completions zsh --install --print)
+          test -z "$path" && { echo "FAIL: --print returned empty"; exit 1; }
+          test ! -e "$path" || { echo "FAIL: --print should not write file"; exit 1; }
+
+          # Install for each shell, verify file exists and starts plausibly.
+          for shell in bash zsh fish; do
+            cargo run --quiet -- completions $shell --install
+          done
+          test -s "$HOME/.local/share/zsh/site-functions/_bcmr"
+          test -s "$HOME/.local/share/bash-completion/completions/bcmr"
+          test -s "$HOME/.config/fish/completions/bcmr.fish"
+
+          # Uninstall removes the file.
+          cargo run --quiet -- completions zsh --install --uninstall
+          test ! -e "$HOME/.local/share/zsh/site-functions/_bcmr"
+
+          # PowerShell --install should be rejected (manual install only).
+          if cargo run --quiet -- completions powershell --install 2>/dev/null; then
+            echo "FAIL: --install should reject powershell"
+            exit 1
+          fi
+
+          # Conflict: --print + --uninstall rejected by clap.
+          if cargo run --quiet -- completions zsh --install --print --uninstall 2>/dev/null; then
+            echo "FAIL: --print + --uninstall should be rejected"
+            exit 1
+          fi
+
+          # --install requires a shell argument (clap requires=...).
+          if cargo run --quiet -- completions --print 2>/dev/null; then
+            echo "FAIL: --print without --install should be rejected"
+            exit 1
+          fi
+
+          echo "completions install tests passed"
+
       - name: Test PowerShell completions (Windows)
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,43 +66,42 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          export HOME=$(mktemp -d)
+          # rustup reads $HOME for its toolchain config; build once with the
+          # real HOME, then run the binary directly with a temp HOME.
+          cargo build --quiet
+          BCMR=./target/debug/bcmr
+          FAKE=$(mktemp -d)
 
-          # --print should NOT write the file.
-          path=$(cargo run --quiet -- completions zsh --install --print)
+          path=$(HOME=$FAKE $BCMR completions zsh --install --print)
           test -z "$path" && { echo "FAIL: --print returned empty"; exit 1; }
           test ! -e "$path" || { echo "FAIL: --print should not write file"; exit 1; }
 
-          # Install for each shell, verify file exists and starts plausibly.
           for shell in bash zsh fish; do
-            cargo run --quiet -- completions $shell --install
+            HOME=$FAKE $BCMR completions $shell --install
           done
-          test -s "$HOME/.local/share/zsh/site-functions/_bcmr"
-          test -s "$HOME/.local/share/bash-completion/completions/bcmr"
-          test -s "$HOME/.config/fish/completions/bcmr.fish"
+          test -s "$FAKE/.local/share/zsh/site-functions/_bcmr"
+          test -s "$FAKE/.local/share/bash-completion/completions/bcmr"
+          test -s "$FAKE/.config/fish/completions/bcmr.fish"
 
-          # Uninstall removes the file.
-          cargo run --quiet -- completions zsh --install --uninstall
-          test ! -e "$HOME/.local/share/zsh/site-functions/_bcmr"
+          HOME=$FAKE $BCMR completions zsh --install --uninstall
+          test ! -e "$FAKE/.local/share/zsh/site-functions/_bcmr"
 
-          # PowerShell --install should be rejected (manual install only).
-          if cargo run --quiet -- completions powershell --install 2>/dev/null; then
+          if HOME=$FAKE $BCMR completions powershell --install 2>/dev/null; then
             echo "FAIL: --install should reject powershell"
             exit 1
           fi
 
-          # Conflict: --print + --uninstall rejected by clap.
-          if cargo run --quiet -- completions zsh --install --print --uninstall 2>/dev/null; then
+          if HOME=$FAKE $BCMR completions zsh --install --print --uninstall 2>/dev/null; then
             echo "FAIL: --print + --uninstall should be rejected"
             exit 1
           fi
 
-          # --install requires a shell argument (clap requires=...).
-          if cargo run --quiet -- completions --print 2>/dev/null; then
+          if HOME=$FAKE $BCMR completions --print 2>/dev/null; then
             echo "FAIL: --print without --install should be rejected"
             exit 1
           fi
 
+          rm -rf "$FAKE"
           echo "completions install tests passed"
 
       - name: Test PowerShell completions (Windows)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,35 +68,38 @@ jobs:
         run: |
           # rustup reads $HOME for its toolchain config; build once with the
           # real HOME, then run the binary directly with a temp HOME.
+          # Clear XDG_*_HOME for the HOME-fallback assertions — the runner
+          # may export them, which would override our isolated $FAKE root.
           cargo build --quiet
           BCMR=./target/debug/bcmr
           FAKE=$(mktemp -d)
+          run_isolated() { HOME=$FAKE XDG_DATA_HOME= XDG_CONFIG_HOME= "$@"; }
 
-          path=$(HOME=$FAKE $BCMR completions zsh --install --print)
+          path=$(run_isolated $BCMR completions zsh --install --print)
           test -z "$path" && { echo "FAIL: --print returned empty"; exit 1; }
           test ! -e "$path" || { echo "FAIL: --print should not write file"; exit 1; }
 
           for shell in bash zsh fish; do
-            HOME=$FAKE $BCMR completions $shell --install
+            run_isolated $BCMR completions $shell --install
           done
-          test -s "$FAKE/.local/share/zsh/site-functions/_bcmr"
-          test -s "$FAKE/.local/share/bash-completion/completions/bcmr"
-          test -s "$FAKE/.config/fish/completions/bcmr.fish"
+          test -s "$FAKE/.local/share/zsh/site-functions/_bcmr" || { echo "FAIL: zsh path"; exit 1; }
+          test -s "$FAKE/.local/share/bash-completion/completions/bcmr" || { echo "FAIL: bash path"; exit 1; }
+          test -s "$FAKE/.config/fish/completions/bcmr.fish" || { echo "FAIL: fish path"; exit 1; }
 
-          HOME=$FAKE $BCMR completions zsh --install --uninstall
+          run_isolated $BCMR completions zsh --install --uninstall
           test ! -e "$FAKE/.local/share/zsh/site-functions/_bcmr"
 
-          if HOME=$FAKE $BCMR completions powershell --install 2>/dev/null; then
+          if run_isolated $BCMR completions powershell --install 2>/dev/null; then
             echo "FAIL: --install should reject powershell"
             exit 1
           fi
 
-          if HOME=$FAKE $BCMR completions zsh --install --print --uninstall 2>/dev/null; then
+          if run_isolated $BCMR completions zsh --install --print --uninstall 2>/dev/null; then
             echo "FAIL: --print + --uninstall should be rejected"
             exit 1
           fi
 
-          if HOME=$FAKE $BCMR completions --print 2>/dev/null; then
+          if run_isolated $BCMR completions --print 2>/dev/null; then
             echo "FAIL: --print without --install should be rejected"
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,14 @@ jobs:
             exit 1
           fi
 
+          # XDG override: the install path must follow XDG_DATA_HOME, not just $HOME.
+          XDG_DATA=$(mktemp -d)
+          xdg_path=$(HOME=$FAKE XDG_DATA_HOME=$XDG_DATA $BCMR completions zsh --install --print)
+          [ "$xdg_path" = "$XDG_DATA/zsh/site-functions/_bcmr" ] || {
+            echo "FAIL: XDG_DATA_HOME not honored; got '$xdg_path'"; exit 1;
+          }
+          rm -rf "$XDG_DATA"
+
           rm -rf "$FAKE"
           echo "completions install tests passed"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,12 +64,12 @@ zstd = { version = "0.13", default-features = false }
 # materially past SSH's ~500 MB/s single-stream ceiling.
 ring = "0.17"
 zeroize = { version = "1.8", features = ["derive"] }
+tempfile = "3"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 xattr = "1.5"
 
 [dev-dependencies]
-tempfile = "3"
 proptest = "1.5"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -335,6 +335,18 @@ pub enum Commands {
     Completions {
         /// Shell to generate completions for
         shell: clap_complete::Shell,
+
+        /// Write the completion script to the conventional shell path
+        #[arg(long)]
+        install: bool,
+
+        /// With --install, only print the target path; do not write
+        #[arg(long, requires = "install")]
+        print: bool,
+
+        /// With --install, remove the file at the conventional path
+        #[arg(long, requires = "install", conflicts_with = "print")]
+        uninstall: bool,
     },
 
     /// Diagnose local + remote setup (ssh / config / bcmr presence)

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,0 +1,90 @@
+use anyhow::{anyhow, bail, Result};
+use std::path::PathBuf;
+
+pub fn install_path(shell: clap_complete::Shell) -> Result<PathBuf> {
+    let home = directories::UserDirs::new()
+        .map(|u| u.home_dir().to_path_buf())
+        .ok_or_else(|| anyhow!("could not resolve $HOME"))?;
+    let path = match shell {
+        clap_complete::Shell::Bash => home
+            .join(".local")
+            .join("share")
+            .join("bash-completion")
+            .join("completions")
+            .join("bcmr"),
+        clap_complete::Shell::Zsh => home
+            .join(".local")
+            .join("share")
+            .join("zsh")
+            .join("site-functions")
+            .join("_bcmr"),
+        clap_complete::Shell::Fish => home
+            .join(".config")
+            .join("fish")
+            .join("completions")
+            .join("bcmr.fish"),
+        clap_complete::Shell::PowerShell => bail!(
+            "PowerShell completions are not auto-installable; \
+             append the output of 'bcmr completions powershell' to your $PROFILE"
+        ),
+        clap_complete::Shell::Elvish => home
+            .join(".config")
+            .join("elvish")
+            .join("lib")
+            .join("bcmr.elv"),
+        other => bail!("unsupported shell for --install: {other:?}"),
+    };
+    Ok(path)
+}
+
+pub fn run_install(
+    shell: clap_complete::Shell,
+    script: &str,
+    print: bool,
+    uninstall: bool,
+) -> Result<()> {
+    let path = install_path(shell)?;
+
+    if print {
+        println!("{}", path.display());
+        return Ok(());
+    }
+
+    if uninstall {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                eprintln!("Removed {}", path.display());
+                shell_reload_hint(shell);
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("Nothing to remove at {}", path.display());
+                Ok(())
+            }
+            Err(e) => Err(anyhow!("cannot remove {}: {}", path.display(), e)),
+        }
+    } else {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| anyhow!("cannot create {}: {}", parent.display(), e))?;
+        }
+        std::fs::write(&path, script)
+            .map_err(|e| anyhow!("cannot write {}: {}", path.display(), e))?;
+        eprintln!("Installed {} ({})", path.display(), shell);
+        shell_reload_hint(shell);
+        Ok(())
+    }
+}
+
+fn shell_reload_hint(shell: clap_complete::Shell) {
+    let hint = match shell {
+        clap_complete::Shell::Bash => "Reload: exec bash  (or open a new shell)",
+        clap_complete::Shell::Zsh => {
+            "Reload: ensure ~/.local/share/zsh/site-functions is on $fpath, then run 'compinit'"
+        }
+        clap_complete::Shell::Fish => "Fish loads it on next shell start.",
+        clap_complete::Shell::Elvish => "Elvish loads it on next shell start.",
+        _ => return,
+    };
+    eprintln!("{}", hint);
+}

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,40 +1,42 @@
 use anyhow::{anyhow, bail, Result};
+use std::io::Write;
 use std::path::PathBuf;
 
 pub fn install_path(shell: clap_complete::Shell) -> Result<PathBuf> {
     let home = directories::UserDirs::new()
         .map(|u| u.home_dir().to_path_buf())
         .ok_or_else(|| anyhow!("could not resolve $HOME"))?;
+    let data = xdg_dir("XDG_DATA_HOME", &home, &[".local", "share"]);
+    let config = xdg_dir("XDG_CONFIG_HOME", &home, &[".config"]);
     let path = match shell {
-        clap_complete::Shell::Bash => home
-            .join(".local")
-            .join("share")
+        clap_complete::Shell::Bash => data
             .join("bash-completion")
             .join("completions")
             .join("bcmr"),
-        clap_complete::Shell::Zsh => home
-            .join(".local")
-            .join("share")
-            .join("zsh")
-            .join("site-functions")
-            .join("_bcmr"),
-        clap_complete::Shell::Fish => home
-            .join(".config")
-            .join("fish")
-            .join("completions")
-            .join("bcmr.fish"),
+        clap_complete::Shell::Zsh => data.join("zsh").join("site-functions").join("_bcmr"),
+        clap_complete::Shell::Fish => config.join("fish").join("completions").join("bcmr.fish"),
         clap_complete::Shell::PowerShell => bail!(
             "PowerShell completions are not auto-installable; \
              append the output of 'bcmr completions powershell' to your $PROFILE"
         ),
-        clap_complete::Shell::Elvish => home
-            .join(".config")
-            .join("elvish")
-            .join("lib")
-            .join("bcmr.elv"),
+        clap_complete::Shell::Elvish => config.join("elvish").join("lib").join("bcmr.elv"),
         other => bail!("unsupported shell for --install: {other:?}"),
     };
     Ok(path)
+}
+
+fn xdg_dir(var: &str, home: &std::path::Path, fallback_segments: &[&str]) -> PathBuf {
+    if let Some(v) = std::env::var_os(var) {
+        let p = PathBuf::from(v);
+        if p.is_absolute() {
+            return p;
+        }
+    }
+    let mut p = home.to_path_buf();
+    for seg in fallback_segments {
+        p.push(seg);
+    }
+    p
 }
 
 pub fn run_install(
@@ -51,36 +53,50 @@ pub fn run_install(
     }
 
     if uninstall {
-        match std::fs::remove_file(&path) {
-            Ok(()) => {
-                eprintln!("Removed {}", path.display());
-                shell_reload_hint(shell);
-                Ok(())
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                eprintln!("Nothing to remove at {}", path.display());
-                Ok(())
-            }
-            Err(e) => Err(anyhow!("cannot remove {}: {}", path.display(), e)),
+        return remove_install(shell, &path);
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow!("cannot create {}: {}", parent.display(), e))?;
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("install path has no parent: {}", path.display()))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| anyhow!("cannot stage temp file in {}: {}", parent.display(), e))?;
+    tmp.write_all(script.as_bytes())
+        .map_err(|e| anyhow!("cannot write staged completion script: {}", e))?;
+    tmp.persist(&path)
+        .map_err(|e| anyhow!("cannot install {}: {}", path.display(), e))?;
+    eprintln!("Installed {} ({})", path.display(), shell);
+    shell_reload_hint(shell);
+    Ok(())
+}
+
+fn remove_install(shell: clap_complete::Shell, path: &std::path::Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => {
+            eprintln!("Removed {}", path.display());
+            shell_reload_hint(shell);
+            Ok(())
         }
-    } else {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| anyhow!("cannot create {}: {}", parent.display(), e))?;
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("Nothing to remove at {}", path.display());
+            Ok(())
         }
-        std::fs::write(&path, script)
-            .map_err(|e| anyhow!("cannot write {}: {}", path.display(), e))?;
-        eprintln!("Installed {} ({})", path.display(), shell);
-        shell_reload_hint(shell);
-        Ok(())
+        Err(e) => Err(anyhow!("cannot remove {}: {}", path.display(), e)),
     }
 }
 
 fn shell_reload_hint(shell: clap_complete::Shell) {
     let hint = match shell {
-        clap_complete::Shell::Bash => "Reload: exec bash  (or open a new shell)",
+        clap_complete::Shell::Bash => {
+            "Reload: open a new shell. \
+             Requires the bash-completion package to be installed and sourced from your rc file."
+        }
         clap_complete::Shell::Zsh => {
-            "Reload: ensure ~/.local/share/zsh/site-functions is on $fpath, then run 'compinit'"
+            "Reload: ensure $XDG_DATA_HOME/zsh/site-functions is on $fpath, then run 'compinit'"
         }
         clap_complete::Shell::Fish => "Fish loads it on next shell start.",
         clap_complete::Shell::Elvish => "Elvish loads it on next shell start.",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod check;
+pub mod completions;
 pub mod copy;
 mod copy_strategies;
 pub mod deploy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,25 +177,34 @@ async fn main() -> Result<()> {
                 println!("{}", entry);
             }
         }
-        Commands::Completions { shell } => {
+        Commands::Completions {
+            shell,
+            install,
+            print,
+            uninstall,
+        } => {
             let mut cmd = build_completion_command();
             let mut buf = Vec::new();
             clap_complete::generate(*shell, &mut cmd, "bcmr", &mut buf);
             let base = String::from_utf8(buf).expect("clap generated invalid UTF-8");
 
-            if *shell == clap_complete::Shell::PowerShell {
-                let injected = base.replacen(
+            let script = if *shell == clap_complete::Shell::PowerShell {
+                base.replacen(
                     "param($wordToComplete, $commandAst, $cursorPosition)\n",
                     &format!(
                         "param($wordToComplete, $commandAst, $cursorPosition)\n{}\n",
                         POWERSHELL_REMOTE_INJECT
                     ),
                     1,
-                );
-                print!("{}", injected);
+                )
             } else {
-                print!("{}", base);
-                print!("{}", remote_completion_script(shell));
+                format!("{}{}", base, remote_completion_script(shell))
+            };
+
+            if *install {
+                commands::completions::run_install(*shell, &script, *print, *uninstall)?;
+            } else {
+                print!("{}", script);
             }
         }
     }


### PR DESCRIPTION
Closes #75 (completions half; defers \`bcmr init <shell> --install\` to a follow-up).

## Summary

\`bcmr completions <shell>\` printed the script to stdout. To actually use it the user had to know (a) the conventional completion path for their distro, (b) how to redirect, (c) how to \`compinit\`. \`gh completion --install\` solves this in one shot; bcmr should match.

## What changes

Three new flags on \`bcmr completions <shell>\`:

\`\`\`
--install                # write the script to the conventional path
--install --print        # only print the target path (dry-run)
--install --uninstall    # remove the file at the conventional path
\`\`\`

Conventional paths (XDG-aligned, user-only, no sudo):

| Shell      | Path                                                         |
| ---------- | ------------------------------------------------------------ |
| bash       | \`~/.local/share/bash-completion/completions/bcmr\`            |
| zsh        | \`~/.local/share/zsh/site-functions/_bcmr\`                    |
| fish       | \`~/.config/fish/completions/bcmr.fish\`                       |
| elvish     | \`~/.config/elvish/lib/bcmr.elv\`                              |
| powershell | (rejected — manual install required, hint points at \`\$PROFILE\`) |

After install, a shell-specific reload hint prints to stderr.

## Out of scope

The issue also asks for \`bcmr init <shell> --install\` to write the rcfile snippet for the \`bcp\`/\`bmv\`/\`brm\` aliases. That's a separate concern with its own idempotency story (mark/unmark blocks in \`~/.zshrc\`); worth its own PR.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] CI: new \`Test completions install / uninstall\` step (POSIX) covers \`--print\` (no-write), \`--install\` for bash/zsh/fish, \`--uninstall\`, PowerShell rejection, and two clap conflict gates (\`--print + --uninstall\`, \`--print\` without \`--install\`).
- [x] Live: install/uninstall round-trip into a tempdir \`HOME\` writes the script and removes it cleanly. PowerShell \`--install\` errors with the manual-install hint.