### PR TITLE
feat(ui): surface 'verified' in Done summary when -V used (#76)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,8 +121,19 @@ jobs:
         shell: bash
         run: |
           echo "verify-test-content" > /tmp/bcmr-test-src/verify.txt
-          cargo run -- copy --verify /tmp/bcmr-test-src/verify.txt /tmp/bcmr-test-dst/
+          # The Done line should advertise the verify pass.
+          out=$(cargo run --quiet -- copy --plain --verify /tmp/bcmr-test-src/verify.txt /tmp/bcmr-test-dst/ 2>&1)
+          echo "$out"
+          echo "$out" | grep -q "verified" || { echo "FAIL: expected 'verified' in Done line under -V"; exit 1; }
           diff /tmp/bcmr-test-src/verify.txt /tmp/bcmr-test-dst/verify.txt
+
+          # And without -V, no 'verified' suffix.
+          rm /tmp/bcmr-test-dst/verify.txt
+          out2=$(cargo run --quiet -- copy --plain /tmp/bcmr-test-src/verify.txt /tmp/bcmr-test-dst/ 2>&1)
+          if echo "$out2" | grep -q "verified"; then
+            echo "FAIL: 'verified' should not appear without -V"
+            exit 1
+          fi
           echo "Copy with verify passed"
 
       - name: Test copy with preserve

--- a/docs/ablation/json-schema.md
+++ b/docs/ablation/json-schema.md
@@ -91,6 +91,8 @@ Error:
 | `bytes_total`     | number   | ✅       | Bytes actually transferred (may be less than the planned total on error).      |
 | `duration_secs`   | number   | ✅       | Wall-clock seconds for the run. Float.                                         |
 | `avg_speed_bps`   | number   | ✅       | **Bytes per second**. Omitted on error.                                        |
+| `bytes_skipped`   | number   | ✅       | Bytes skipped via `--append` / `--update`. Omitted when `0`.                   |
+| `verified`        | bool     | ✅       | `true` when the run was invoked with `-V/--verify`. Omitted when `false`.      |
 | `error`           | string   | ✅       | Human-readable error. Present only when `status="error"`.                      |
 
 ## `bcmr check --json`
@@ -133,7 +135,7 @@ When a background job fails, the log file ends with a single `result` event whos
 
 - **Schema versioning.** No `version` field today. Treat the schema as v0; assume best-effort backwards compat within a minor release.
 - **`phase` events.** A consumer wanting to know "scan phase finished, transfer phase started" today infers it from `scanning: true → false` between two `progress` events. A future explicit `{"type":"phase","name":"scan_complete"}` would beat the heuristic.
-- **`bytes_skipped`.** When `--update` or `--append` lands, the `result` will gain a `bytes_skipped` counter. Consumers can pre-emptively treat absent `bytes_skipped` as `0`.
+- **Reflink / dedup / compress counters.** A future PR will add `reflink_count`, `dedup_count`, and `compress_ratio` to the `result` event. Treat absent fields as zero/unknown.
 - **Operation-string enum.** `operation` is freeform today. Don't pattern-match; if you need to know the phase, use `scanning` or upcoming `phase` events.
 
 ## See also

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -242,6 +242,7 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
             let mut p = runner.progress().lock();
             p.set_operation_type("Copying");
             p.set_scanning(true);
+            p.set_verify_mode(args.is_verify());
             if let Some(first) = sources.first() {
                 let display_name = first.file_name().unwrap_or_default().to_string_lossy();
                 p.set_current_file(&display_name, 0);

--- a/src/app/runners.rs
+++ b/src/app/runners.rs
@@ -44,6 +44,7 @@ pub(crate) fn resume_or_new_runner(
             let mut p = r.progress().lock();
             p.set_total_bytes(total_size);
             p.set_scanning(false);
+            p.set_verify_mode(args.is_verify());
             if let Some(name) = first_display {
                 p.set_current_file(name, total_size);
             }
@@ -60,6 +61,7 @@ pub(crate) fn resume_or_new_runner(
     {
         let mut p = r.progress().lock();
         p.set_operation_type(operation);
+        p.set_verify_mode(args.is_verify());
         if let Some(name) = first_display {
             p.set_current_file(name, total_size);
         }

--- a/src/commands/remote_copy/legacy.rs
+++ b/src/commands/remote_copy/legacy.rs
@@ -69,7 +69,11 @@ pub(super) async fn handle_remote_upload(
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;
-    runner.progress().lock().set_operation_type("Uploading");
+    {
+        let mut p = runner.progress().lock();
+        p.set_operation_type("Uploading");
+        p.set_verify_mode(args.is_verify());
+    }
     let multi_source = sources.len() > 1;
 
     if parallel > 1 {
@@ -205,7 +209,11 @@ pub(super) async fn handle_remote_download(
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;
-    runner.progress().lock().set_operation_type("Downloading");
+    {
+        let mut p = runner.progress().lock();
+        p.set_operation_type("Downloading");
+        p.set_verify_mode(args.is_verify());
+    }
 
     if parallel > 1 {
         runner.set_parallel_mode(parallel);

--- a/src/commands/remote_copy/serve.rs
+++ b/src/commands/remote_copy/serve.rs
@@ -121,10 +121,11 @@ pub(super) async fn handle_serve_upload(
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;
-    runner
-        .progress()
-        .lock()
-        .set_operation_type("Uploading (serve)");
+    {
+        let mut p = runner.progress().lock();
+        p.set_operation_type("Uploading (serve)");
+        p.set_verify_mode(args.is_verify());
+    }
 
     let multi_source = sources.len() > 1;
     for src in sources {
@@ -416,10 +417,11 @@ pub(super) async fn handle_serve_download(
         crate::config::is_json_mode(),
         crate::commands::copy::cleanup_partial_files,
     )?;
-    runner
-        .progress()
-        .lock()
-        .set_operation_type("Downloading (serve)");
+    {
+        let mut p = runner.progress().lock();
+        p.set_operation_type("Downloading (serve)");
+        p.set_verify_mode(args.is_verify());
+    }
 
     let use_stripe = args.use_direct_tcp() && pool.len() > 1 && !args.is_verify();
     let mut big_files: Vec<(String, PathBuf, u64)> = Vec::new();

--- a/src/ui/inline.rs
+++ b/src/ui/inline.rs
@@ -193,6 +193,10 @@ impl ProgressRenderer for InlineProgress {
         let _ = self.redraw();
     }
 
+    fn set_verify_mode(&mut self, on: bool) {
+        self.data.verify_mode = on;
+    }
+
     fn inc_items_processed(&mut self) {
         self.data.items_processed += 1;
         let _ = self.redraw();

--- a/src/ui/json.rs
+++ b/src/ui/json.rs
@@ -83,6 +83,10 @@ struct ResultLine<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     avg_speed_bps: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    bytes_skipped: Option<u64>,
+    #[serde(skip_serializing_if = "core::ops::Not::not")]
+    verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<&'a str>,
 }
 
@@ -225,6 +229,8 @@ impl ProgressRenderer for JsonProgress {
             bytes_total: self.data.current_bytes,
             duration_secs: elapsed.as_secs_f64(),
             avg_speed_bps: avg_bps,
+            bytes_skipped: (self.data.skipped_bytes > 0).then_some(self.data.skipped_bytes),
+            verified: self.data.verify_mode,
             error: None,
         };
 
@@ -245,9 +251,15 @@ impl ProgressRenderer for JsonProgress {
             bytes_total: self.data.current_bytes,
             duration_secs: elapsed.as_secs_f64(),
             avg_speed_bps: None,
+            bytes_skipped: (self.data.skipped_bytes > 0).then_some(self.data.skipped_bytes),
+            verified: self.data.verify_mode,
             error: Some(msg),
         };
 
         self.writer.write_line_strict(&line)
+    }
+
+    fn set_verify_mode(&mut self, on: bool) {
+        self.data.verify_mode = on;
     }
 }

--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -28,6 +28,8 @@ pub trait ProgressRenderer: Send {
     fn update_worker(&mut self, _slot: usize, _file_name: &str, _file_size: u64, _progress: u64) {}
     fn finish_worker(&mut self, _slot: usize) {}
 
+    fn set_verify_mode(&mut self, _on: bool) {}
+
     fn tick(&mut self) {}
 }
 
@@ -60,6 +62,10 @@ impl ProgressRenderer for PlainTextProgress {
     fn finish(&mut self) -> io::Result<()> {
         println!("{}", self.data.done_summary_line());
         Ok(())
+    }
+
+    fn set_verify_mode(&mut self, on: bool) {
+        self.data.verify_mode = on;
     }
 }
 

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -61,6 +61,7 @@ pub struct ProgressData {
     pub files_found: u64,
     pub workers: Vec<WorkerState>,
     pub parallel_total: usize,
+    pub verify_mode: bool,
 }
 
 impl ProgressData {
@@ -86,6 +87,7 @@ impl ProgressData {
             files_found: 0,
             workers: Vec::new(),
             parallel_total: 0,
+            verify_mode: false,
         }
     }
 
@@ -195,6 +197,9 @@ impl ProgressData {
                 format_bytes(self.skipped_bytes as f64)
             ));
         }
+        if self.verify_mode {
+            line.push_str(" | verified");
+        }
         line
     }
 }
@@ -296,5 +301,16 @@ mod tests {
             line.contains("30"),
             "expected skipped MiB count, got: {line}"
         );
+    }
+
+    #[test]
+    fn test_done_summary_appends_verified_when_set() {
+        let mut pd = ProgressData::new(1024);
+        pd.current_bytes = 1024;
+        let plain = pd.done_summary_line();
+        assert!(!plain.contains("verified"), "got: {plain}");
+        pd.verify_mode = true;
+        let with = pd.done_summary_line();
+        assert!(with.contains("verified"), "got: {with}");
     }
 }

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -497,6 +497,10 @@ impl ProgressRenderer for TuiProgress {
         let _ = self.redraw();
     }
 
+    fn set_verify_mode(&mut self, on: bool) {
+        self.data.verify_mode = on;
+    }
+
     fn inc_items_processed(&mut self) {
         self.data.items_processed += 1;
         let _ = self.redraw();


### PR DESCRIPTION
Closes #76 (continuation). PR #100 shipped \`skipped\` for size-matched files; this PR ships \`verified\` for runs invoked with \`-V/--verify\` so the user-visible summary actually reflects what the copy backend did.

## What changes

\`\`\`
\$ bcmr copy a.bin b.bin
Done: 100 MiB in 0.5s | avg 200 MiB/s

\$ bcmr copy --verify a.bin b.bin
Done: 100 MiB in 0.7s | avg 142 MiB/s | verified
\`\`\`

Under \`--json\`, the \`result\` event also gains two new optional fields:

\`\`\`json
{"type":"result","status":"success","bytes_total":104857600,"duration_secs":0.7,"avg_speed_bps":149796571,"bytes_skipped":52428800,"verified":true}
\`\`\`

Both \`bytes_skipped\` and \`verified\` are omitted when zero/false — pre-existing log consumers see no schema break.

## Wiring

- \`ProgressData\` gains \`verify_mode: bool\`. \`done_summary_line()\` appends \` | verified\`.
- \`ProgressRenderer\` trait gains \`set_verify_mode(on: bool)\` with a default no-op. Implemented on \`PlainTextProgress\`, \`InlineProgress\`, \`TuiProgress\`, \`JsonProgress\`.
- Called from every \`ProgressRunner\` construction site: \`resume_or_new_runner\` (copy/move resume + remove), the bare-runner non-resume copy path in \`app/commands.rs\`, and all four \`remote_copy/{legacy,serve}.rs\` sites.

## Out of scope

The other facts #76 lists — reflink count, dedup count, compress ratio — need new counters threaded through the copy backend itself (file_copy.rs, copy_strategies.rs, remote serve compress block). Deferred to follow-ups; the scaffold is in place (\`ProgressData\` is the obvious accumulator).

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] New unit test \`test_done_summary_appends_verified_when_set\` in \`src/ui/state.rs\`
- [x] CI: \`Test copy with verify\` step now asserts \`verified\` shows under \`-V\` and is absent without — end-to-end on both \`ubuntu-latest\` and \`windows-latest\`
- [x] Live: \`bcmr copy --plain a b\` no suffix; \`bcmr copy --plain -V a b\` shows \`| verified\`
- [x] Schema doc updated: \`docs/ablation/json-schema.md\` result table gains \`bytes_skipped\` + \`verified\` rows; the deferred-features note now lists reflink/dedup/compress