### PR TITLE
feat(ux): no-args shows common-usage hint, not bare clap help (#83)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -331,3 +331,18 @@ jobs:
           cargo run -- update --help
           cargo run -- completions --help
           echo "Help/version tests passed"
+
+      - name: Test no-args common-usage hint
+        shell: bash
+        run: |
+          # Bare 'bcmr' should exit 0 and print the common-usage block.
+          out=$(cargo run --quiet)
+          echo "$out"
+          echo "$out" | grep -q "Common usage:" || { echo "FAIL: missing 'Common usage:' header"; exit 1; }
+          echo "$out" | grep -q "bcmr copy -r src/ host:dst/" || { echo "FAIL: missing example"; exit 1; }
+          echo "$out" | grep -q "bcmr help" || { echo "FAIL: missing help pointer"; exit 1; }
+
+          # Subcommand typo should suggest the closest match (clap default).
+          err=$(cargo run --quiet -- cp 2>&1 || true)
+          echo "$err" | grep -q "copy" || { echo "FAIL: did-you-mean did not suggest 'copy' for 'cp'"; exit 1; }
+          echo "no-args + did-you-mean tests passed"

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,31 @@ fn maybe_detach(cli: &cli::Cli) -> Result<bool> {
     Ok(true)
 }
 
+const NO_ARGS_HINT: &str = "\
+Better Copy Move Remove (BCMR) — modern cp/mv/scp/rm with progress, resume, and remote support.
+
+Common usage:
+  bcmr copy -r src/ host:dst/        # SSH copy, recursive, with progress
+  bcmr copy -V file host:dst/        # full BLAKE3 verify
+  bcmr move -r old/ archive/
+  bcmr check -r src/ host:dst/       # compare without copying
+
+  bcmr deploy <host>                 # install bcmr remotely for fast-path
+  bcmr init zsh                      # set up shell integration (bcp/bmv/brm)
+  bcmr completions install zsh       # one-shot completion install
+  bcmr doctor                        # diagnose ssh / config / PATH issues
+
+Type `bcmr help <command>` or `bcmr <command> --help` for full options.
+Configuration: ~/.config/bcmr/config.toml
+";
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    if std::env::args().len() == 1 {
+        print!("{}", NO_ARGS_HINT);
+        return Ok(());
+    }
+
     let cli = cli::parse_args();
 
     if let Some(ref path) = cli.config {


### PR DESCRIPTION
Closes #83 (sub-issue A only); explicitly defers B, C, D with reasons.

## Summary

\`bcmr\` typed alone printed the raw clap help — a wall of subcommand names with no examples or pointers. New users had to read the README in another window to make progress.

## What changes

\`\`\`
\$ bcmr
Better Copy Move Remove (BCMR) — modern cp/mv/scp/rm with progress, resume, and remote support.

Common usage:
  bcmr copy -r src/ host:dst/        # SSH copy, recursive, with progress
  bcmr copy -V file host:dst/        # full BLAKE3 verify
  bcmr move -r old/ archive/
  bcmr check -r src/ host:dst/       # compare without copying

  bcmr deploy <host>                 # install bcmr remotely for fast-path
  bcmr init zsh                      # set up shell integration (bcp/bmv/brm)
  bcmr completions install zsh       # one-shot completion install
  bcmr doctor                        # diagnose ssh / config / PATH issues

Type \`bcmr help <command>\` or \`bcmr <command> --help\` for full options.
Configuration: ~/.config/bcmr/config.toml
\`\`\`

Single \`if std::env::args().len() == 1\` early-return in \`main()\` before clap parses. No clap config change.

## What's *not* in this PR

- **B (first-run setup hint)** — needs persistent state to track \"has user ever run a copy\". Reasonable but more invasive; defer to a follow-up.
- **C (Ctrl-C \"partial saved\" summary)** — the issue itself flags this as \"must precede #44 first\" (resume corruption). Shipping the recommendation now would point users at a broken resume path.
- **D (did-you-mean)** — clap already suggests by Levenshtein. Verified: \`bcmr cp\` already prints \"some similar subcommands exist: 'copy'\". No code change needed.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] CI: new \`Test no-args common-usage hint\` step asserts bare \`bcmr\` exits 0 with the header + example + help pointer, AND \`bcmr cp\` (typo) still suggests \`copy\` (locks the clap default for D).
- [x] Live: \`bcmr\` produces the new block; \`bcmr --help\`, \`bcmr copy ...\`, etc. unchanged.