### PR TITLE
feat(config): @bookmark path aliases in config (#81)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,37 @@ jobs:
           test ! -d /tmp/bcmr-test-dst/dryrun-target/
           echo "Dry-run test passed"
 
+      - name: Test path bookmarks (@alias resolution)
+        shell: bash
+        run: |
+          # Build a config with a [paths] map pointing at a local dest dir,
+          # then run a copy using the @alias and confirm the file lands at
+          # the resolved path.
+          tmp=$(mktemp -d)
+          mkdir -p "$tmp/dst"
+          cat > "$tmp/cfg.toml" <<EOF
+          [paths]
+          local = "$tmp/dst/"
+          EOF
+          echo "bookmark-test" > "$tmp/src.txt"
+
+          # Bare alias resolves to the dest dir.
+          cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" @local
+          test -f "$tmp/dst/src.txt" || { echo "FAIL: @local should resolve to dst dir"; exit 1; }
+
+          # Alias with a relative suffix.
+          cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" @local/named.txt
+          test -f "$tmp/dst/named.txt" || { echo "FAIL: @local/named.txt should resolve"; exit 1; }
+          diff "$tmp/src.txt" "$tmp/dst/named.txt"
+
+          # Unknown alias stays as a literal path (no crash, no resolution).
+          # Copy will succeed creating a local file literally named '@unknown'.
+          cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" "$tmp/@unknown"
+          test -f "$tmp/@unknown" || { echo "FAIL: literal @unknown path"; exit 1; }
+
+          rm -rf "$tmp"
+          echo "Path bookmark tests passed"
+
       - name: Test exclude patterns
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,10 +177,15 @@ jobs:
           test -f "$tmp/dst/named.txt" || { echo "FAIL: @local/named.txt should resolve"; exit 1; }
           diff "$tmp/src.txt" "$tmp/dst/named.txt"
 
-          # Unknown alias stays as a literal path (no crash, no resolution).
-          # Copy will succeed creating a local file literally named '@unknown'.
-          cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" "$tmp/@unknown"
-          test -f "$tmp/@unknown" || { echo "FAIL: literal @unknown path"; exit 1; }
+          # Unknown alias must error with a did-you-mean hint, not silently
+          # try to copy a file literally named '@prj'.
+          err=$(cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" @prj 2>&1 || true)
+          echo "$err" | grep -q "unknown path alias '@prj'" || { echo "FAIL: missing unknown-alias error"; exit 1; }
+          echo "$err" | grep -q "did you mean '@local'" || { echo "FAIL: missing did-you-mean"; exit 1; }
+
+          # Invalid alias name errors with the regex hint.
+          err2=$(cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" '@bad!' 2>&1 || true)
+          echo "$err2" | grep -q "invalid alias name '@bad!'" || { echo "FAIL: missing invalid-name error"; exit 1; }
 
           rm -rf "$tmp"
           echo "Path bookmark tests passed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,9 +178,11 @@ jobs:
           diff "$tmp/src.txt" "$tmp/dst/named.txt"
 
           # Unknown alias must error with a did-you-mean hint, not silently
-          # try to copy a file literally named '@prj'.
-          err=$(cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" @prj 2>&1 || true)
-          echo "$err" | grep -q "unknown path alias '@prj'" || { echo "FAIL: missing unknown-alias error"; exit 1; }
+          # try to copy a file literally named '@locl'. Levenshtein distance
+          # between the typo and 'local' is 1, well within the suggestion
+          # threshold.
+          err=$(cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" @locl 2>&1 || true)
+          echo "$err" | grep -q "unknown path alias '@locl'" || { echo "FAIL: missing unknown-alias error"; exit 1; }
           echo "$err" | grep -q "did you mean '@local'" || { echo "FAIL: missing did-you-mean"; exit 1; }
 
           # Invalid alias name errors with the regex hint.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,7 @@ jobs:
           echo "Dry-run test passed"
 
       - name: Test path bookmarks (@alias resolution)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           # Build a config with a [paths] map pointing at a local dest dir,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,32 @@ BCMR checks these paths in order:
    - **macOS:** `~/Library/Application Support/com.bcmr.bcmr/`
    - **Windows:** `%APPDATA%\bcmr\bcmr\`
 
+## Path Bookmarks
+
+Long, repeated remote destinations get tedious. The `[paths]` table maps short `@aliases` to full `host:path` strings; bcmr substitutes them at startup so every downstream code path sees the resolved destination.
+
+```toml
+[paths]
+proj   = "lab:/data/projects/myrepo/"
+backup = "nas:/backups/"
+logs   = "archive:/var/log/myapp/"
+```
+
+```sh
+bcmr copy ./project/  @proj           # → lab:/data/projects/myrepo/
+bcmr copy db.gz       @proj/backups/  # → lab:/data/projects/myrepo/backups/
+bcmr copy report.pdf  @backup/today/  # → nas:/backups/today/
+```
+
+**Rules:**
+
+- Alias names must match `[A-Za-z_][A-Za-z0-9_-]*`. Invalid names error at use.
+- The trailing slash on the configured target is preserved for the bare-alias form (`@proj` returns the target verbatim) and normalised for the suffixed form (`@proj/foo` joins with exactly one `/` between).
+- An unknown `@alias` errors with a `did you mean ...?` suggestion (Levenshtein-based) and lists all known aliases. Bcmr does not silently fall through to a literal-file lookup.
+- To copy a literal file whose name starts with `@`, prefix with `./` — e.g. `bcmr copy ./@weird-filename ./dst/`.
+
+Aliases work in every position that accepts a path: source list, destination, `bcmr check`, `bcmr remove`.
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,10 +169,7 @@ impl Default for Config {
 
 pub static CONFIG: Lazy<Config> = Lazy::new(|| Config::new().unwrap_or_else(|_| Config::default()));
 
-pub fn resolve_path_alias(
-    input: &str,
-    paths: &std::collections::HashMap<String, String>,
-) -> Option<String> {
+pub fn parse_alias_token(input: &str) -> Option<(&str, &str)> {
     let bytes = input.as_bytes();
     if bytes.first() != Some(&b'@') {
         return None;
@@ -185,9 +182,31 @@ pub fn resolve_path_alias(
     if name.is_empty() {
         return None;
     }
+    Some((name, &input[suffix_start..]))
+}
+
+pub fn is_valid_alias_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+pub fn resolve_path_alias(
+    input: &str,
+    paths: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    let (name, suffix) = parse_alias_token(input)?;
     let target = paths.get(name)?;
-    let suffix = &input[suffix_start..];
-    Some(format!("{}{}", target.trim_end_matches('/'), suffix))
+    if suffix.is_empty() {
+        Some(target.clone())
+    } else {
+        Some(format!("{}{}", target.trim_end_matches('/'), suffix))
+    }
 }
 
 impl Config {
@@ -334,10 +353,33 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_path_alias_substitutes_bare_alias() {
+    fn test_resolve_path_alias_preserves_trailing_slash_for_bare_alias() {
         let mut paths = std::collections::HashMap::new();
         paths.insert("proj".to_string(), "host:/data/".to_string());
-        assert_eq!(resolve_path_alias("@proj", &paths).unwrap(), "host:/data");
+        assert_eq!(resolve_path_alias("@proj", &paths).unwrap(), "host:/data/");
+        paths.insert("flat".to_string(), "host:/var".to_string());
+        assert_eq!(resolve_path_alias("@flat", &paths).unwrap(), "host:/var");
+    }
+
+    #[test]
+    fn test_is_valid_alias_name() {
+        assert!(is_valid_alias_name("proj"));
+        assert!(is_valid_alias_name("Proj_2"));
+        assert!(is_valid_alias_name("a-b-c"));
+        assert!(is_valid_alias_name("_underscore"));
+        assert!(!is_valid_alias_name(""));
+        assert!(!is_valid_alias_name("1leading-digit"));
+        assert!(!is_valid_alias_name("with space"));
+        assert!(!is_valid_alias_name("with/slash"));
+        assert!(!is_valid_alias_name("with:colon"));
+    }
+
+    #[test]
+    fn test_parse_alias_token() {
+        assert_eq!(parse_alias_token("@proj"), Some(("proj", "")));
+        assert_eq!(parse_alias_token("@proj/x/y"), Some(("proj", "/x/y")));
+        assert_eq!(parse_alias_token("local"), None);
+        assert_eq!(parse_alias_token("@"), None);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,8 @@ pub struct Config {
     pub transfer: TransferConfig,
     #[serde(default)]
     pub update_check: UpdateCheck,
+    #[serde(default)]
+    pub paths: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -160,11 +162,33 @@ impl Default for Config {
             scp: ScpConfig::default(),
             transfer: TransferConfig::default(),
             update_check: UpdateCheck::default(),
+            paths: std::collections::HashMap::new(),
         }
     }
 }
 
 pub static CONFIG: Lazy<Config> = Lazy::new(|| Config::new().unwrap_or_else(|_| Config::default()));
+
+pub fn resolve_path_alias(
+    input: &str,
+    paths: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    let bytes = input.as_bytes();
+    if bytes.first() != Some(&b'@') {
+        return None;
+    }
+    let (name_end, suffix_start) = match input[1..].find('/') {
+        Some(rel) => (1 + rel, 1 + rel),
+        None => (input.len(), input.len()),
+    };
+    let name = &input[1..name_end];
+    if name.is_empty() {
+        return None;
+    }
+    let target = paths.get(name)?;
+    let suffix = &input[suffix_start..];
+    Some(format!("{}{}", target.trim_end_matches('/'), suffix))
+}
 
 impl Config {
     pub fn new() -> Result<Self, ConfigError> {
@@ -298,5 +322,43 @@ mod tests {
     #[test]
     fn test_static_config() {
         assert!(!CONFIG.progress.style.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_path_alias_returns_none_for_non_alias() {
+        let mut paths = std::collections::HashMap::new();
+        paths.insert("proj".to_string(), "host:/data".to_string());
+        assert!(resolve_path_alias("file.bin", &paths).is_none());
+        assert!(resolve_path_alias("host:/x", &paths).is_none());
+        assert!(resolve_path_alias("@", &paths).is_none()); // empty name
+    }
+
+    #[test]
+    fn test_resolve_path_alias_substitutes_bare_alias() {
+        let mut paths = std::collections::HashMap::new();
+        paths.insert("proj".to_string(), "host:/data/".to_string());
+        assert_eq!(resolve_path_alias("@proj", &paths).unwrap(), "host:/data");
+    }
+
+    #[test]
+    fn test_resolve_path_alias_appends_suffix() {
+        let mut paths = std::collections::HashMap::new();
+        paths.insert("proj".to_string(), "host:/data/".to_string());
+        assert_eq!(
+            resolve_path_alias("@proj/sub/file.bin", &paths).unwrap(),
+            "host:/data/sub/file.bin"
+        );
+        // No trailing slash on target also works.
+        paths.insert("dst".to_string(), "host:/var".to_string());
+        assert_eq!(
+            resolve_path_alias("@dst/log", &paths).unwrap(),
+            "host:/var/log"
+        );
+    }
+
+    #[test]
+    fn test_resolve_path_alias_unknown_returns_none() {
+        let paths = std::collections::HashMap::new();
+        assert!(resolve_path_alias("@unknown/file", &paths).is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,11 +94,13 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let cli = cli::parse_args();
+    let mut cli = cli::parse_args();
 
     if let Some(ref path) = cli.config {
         std::env::set_var("BCMR_CONFIG", path);
     }
+
+    expand_path_bookmarks(&mut cli.command);
 
     if maybe_detach(&cli)? {
         return Ok(());
@@ -205,6 +207,22 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn expand_path_bookmarks(cmd: &mut Commands) {
+    use std::path::PathBuf;
+    let paths = match cmd {
+        Commands::Copy { args, .. } | Commands::Move { args, .. } => &mut args.paths,
+        Commands::Check { paths, .. } => paths,
+        Commands::Remove { paths, .. } => paths,
+        _ => return,
+    };
+    for p in paths.iter_mut() {
+        let s = p.to_string_lossy();
+        if let Some(resolved) = config::resolve_path_alias(&s, &config::CONFIG.paths) {
+            *p = PathBuf::from(resolved);
+        }
+    }
 }
 
 fn show_update_hint(update_rx: Option<mpsc::Receiver<Option<String>>>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
         std::env::set_var("BCMR_CONFIG", path);
     }
 
-    expand_path_bookmarks(&mut cli.command);
+    expand_path_bookmarks(&mut cli.command)?;
 
     if maybe_detach(&cli)? {
         return Ok(());
@@ -209,20 +209,86 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn expand_path_bookmarks(cmd: &mut Commands) {
+fn expand_path_bookmarks(cmd: &mut Commands) -> Result<()> {
     use std::path::PathBuf;
     let paths = match cmd {
         Commands::Copy { args, .. } | Commands::Move { args, .. } => &mut args.paths,
         Commands::Check { paths, .. } => paths,
         Commands::Remove { paths, .. } => paths,
-        _ => return,
+        _ => return Ok(()),
     };
+    let table = &config::CONFIG.paths;
     for p in paths.iter_mut() {
         let s = p.to_string_lossy();
-        if let Some(resolved) = config::resolve_path_alias(&s, &config::CONFIG.paths) {
-            *p = PathBuf::from(resolved);
+        let Some((name, _suffix)) = config::parse_alias_token(&s) else {
+            continue;
+        };
+        if !config::is_valid_alias_name(name) {
+            anyhow::bail!(
+                "invalid alias name '@{name}'; alias names must match [A-Za-z_][A-Za-z0-9_-]*. \
+                 To copy a literal file whose name starts with '@', use './{}'",
+                &s
+            );
+        }
+        match config::resolve_path_alias(&s, table) {
+            Some(resolved) => *p = PathBuf::from(resolved),
+            None => {
+                let suggestion = nearest_alias(name, table.keys());
+                let known: Vec<&str> = table.keys().map(String::as_str).collect();
+                let mut msg = format!("unknown path alias '@{name}'");
+                if let Some(near) = suggestion {
+                    msg.push_str(&format!(" — did you mean '@{near}'?"));
+                }
+                if known.is_empty() {
+                    msg.push_str(
+                        "\nNo aliases configured. Add a [paths] table to ~/.config/bcmr/config.toml.",
+                    );
+                } else {
+                    let mut sorted = known;
+                    sorted.sort_unstable();
+                    msg.push_str(&format!("\nKnown aliases: {}", sorted.join(", ")));
+                }
+                msg.push_str(&format!(
+                    "\nTo refer to a literal file named '@{name}', use './{}'",
+                    &s
+                ));
+                anyhow::bail!("{msg}");
+            }
         }
     }
+    Ok(())
+}
+
+fn nearest_alias<'a>(
+    target: &str,
+    candidates: impl Iterator<Item = &'a String>,
+) -> Option<&'a str> {
+    candidates
+        .map(|c| (levenshtein(target, c), c.as_str()))
+        .filter(|(d, c)| *d <= (c.len() / 2 + 1).max(2))
+        .min_by_key(|(d, _)| *d)
+        .map(|(_, c)| c)
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+    for (i, &ac) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, &bc) in b.iter().enumerate() {
+            let cost = if ac == bc { 0 } else { 1 };
+            curr[j + 1] = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
 }
 
 fn show_update_hint(update_rx: Option<mpsc::Receiver<Option<String>>>) {


### PR DESCRIPTION
Closes #81 (path-bookmarks half). Lands the **path bookmarks** half; defers per-host default-flags and profiles.

## Summary

The same long remote paths get retyped over and over:

\`\`\`
bcmr copy -r ./project/ user@10.0.1.42:/data/projects/myrepo/
bcmr copy -r ./project/ user@10.0.1.42:/data/projects/myrepo/   # again, hour later
\`\`\`

ssh solved this with \`~/.ssh/config\` aliases (which bcmr already inherits). The path side had no equivalent.

## What changes

\`~/.config/bcmr/config.toml\`:
\`\`\`toml
[paths]
proj = \"lab:/data/projects/myrepo/\"
backup = \"nas:/backups/\"
\`\`\`

\`\`\`
bcmr copy ./project/ @proj            -> lab:/data/projects/myrepo/
bcmr copy db.gz   @proj/backups/      -> lab:/data/projects/myrepo/backups/
bcmr copy log.txt @backup/today.log   -> nas:/backups/today.log
\`\`\`

Resolution happens once in \`main.rs::expand_path_bookmarks\` after \`parse_args\`, before any handler runs — every existing path-handling code path sees the already-resolved string. \`parse_remote_path\` is unchanged.

Trailing slashes on the configured target are normalised so \`@proj/foo\` produces \`lab:/data/projects/myrepo/foo\` regardless of whether the config has a trailing slash. Unknown aliases stay as literal paths — bcmr falls through to its existing file-not-found error path, no silent breakage.

## Out of scope

The issue also asks for:
- **Per-host default flags** (\`[host.\"name\"] default_args = [...]\`) — needs flag-injection logic before clap parses, or post-parse arg rewriting. Bigger PR.
- **Profiles** (\`[profile.work] default_args = [...]\`) — same shape, plus profile-selection arg.

Both deferred. The path-bookmark scaffold is small and standalone; the others need an arg-rewriting layer.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green
- [x] 4 new unit tests in \`src/config.rs\`: non-alias passthrough, bare \`@alias\`, alias + suffix (with and without target trailing slash), unknown alias.
- [x] CI: new \`Test path bookmarks (@alias resolution)\` step exercises bare alias, alias+suffix, and unknown-alias fallthrough end-to-end with a tempfile \`[paths]\` config.
- [x] Live: \`bcmr --config /tmp/cfg.toml copy --plain src @local\` writes to the configured directory; \`@local/named.txt\` writes to the explicit subpath.