### PR TITLE
feat(status): --watch <job_id> follows a running job's log (#110)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -420,6 +420,23 @@ jobs:
           echo "status: $status"
           echo "$status" | grep -q '"type":"result"' || { echo "FAIL: status did not return result"; exit 1; }
 
+          # bcmr status <id> --watch should replay the existing log and exit
+          # at the result event. The log is already terminal here, so --watch
+          # returns immediately.
+          watch_pretty=$(cargo run --quiet -- status "$job_id" --watch)
+          echo "$watch_pretty"
+          echo "$watch_pretty" | grep -q "Done:" || { echo "FAIL: --watch missing terminal Done line"; exit 1; }
+          watch_json=$(cargo run --quiet -- --json status "$job_id" --watch)
+          echo "$watch_json" | grep -q '"type":"result"' || { echo "FAIL: --watch --json missing result event"; exit 1; }
+
+          # Conflict: --watch needs a job_id, can't pair with --rm/--gc.
+          if cargo run --quiet -- status --watch 2>/dev/null; then
+            echo "FAIL: --watch without job_id should be rejected"; exit 1;
+          fi
+          if cargo run --quiet -- status "$job_id" --watch --rm 2>/dev/null; then
+            echo "FAIL: --watch + --rm should be rejected"; exit 1;
+          fi
+
           # bcmr status --rm <id> should drop just that job's log.
           rm_out=$(cargo run --quiet -- --json status "$job_id" --rm)
           echo "rm: $rm_out"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,6 +437,41 @@ jobs:
             echo "FAIL: --watch + --rm should be rejected"; exit 1;
           fi
 
+          # Stale-job lifecycle: a header pointing at a dead pid + no result event
+          # must error within STARTUP_GRACE rather than poll forever.
+          jobs_dir="${XDG_DATA_HOME:-$HOME/.local/share}/bcmr/jobs"
+          mkdir -p "$jobs_dir"
+          stale_id="stale-$$"
+          dead_pid=$(bash -c 'sleep 0.05 & echo $!; wait')
+          printf '{"job_id":"%s","pid":%s,"log":"%s/%s.jsonl"}\n' \
+            "$stale_id" "$dead_pid" "$jobs_dir" "$stale_id" \
+            > "$jobs_dir/$stale_id.jsonl"
+          start=$(date +%s)
+          if timeout 5 cargo run --quiet -- status "$stale_id" --watch 2>&1; then
+            echo "FAIL: --watch should exit non-zero on stale (writer-dead) job"; exit 1;
+          fi
+          end=$(date +%s)
+          if [ $((end - start)) -gt 4 ]; then
+            echo "FAIL: stale job detection took $((end - start))s (expected <2s)"; exit 1;
+          fi
+          rm -f "$jobs_dir/$stale_id.jsonl"
+
+          # Spawn-then-watch race: kicking off --watch before the writer has flushed
+          # its header must wait through STARTUP_GRACE rather than error 'not found'.
+          race_id="race-$$"
+          live_pid=$$
+          (
+            sleep 0.4
+            printf '{"job_id":"%s","pid":%s,"log":"x"}\n{"type":"result","status":"success","duration_secs":0.1,"bytes_total":0}\n' \
+              "$race_id" "$live_pid" > "$jobs_dir/$race_id.jsonl"
+          ) &
+          out=$(timeout 5 cargo run --quiet -- status "$race_id" --watch 2>&1) || true
+          wait
+          echo "$out" | grep -qE 'Done:|"type":"result"' || {
+            echo "FAIL: race --watch missed result; got: $out"; exit 1;
+          }
+          rm -f "$jobs_dir/$race_id.jsonl"
+
           # bcmr status --rm <id> should drop just that job's log.
           rm_out=$(cargo run --quiet -- --json status "$job_id" --rm)
           echo "rm: $rm_out"

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -1,5 +1,9 @@
 use crate::commands;
 use crate::config::is_json_mode;
+use anyhow::{anyhow, Result};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+use std::time::Duration;
 
 pub(crate) fn status_detail(latest: &str) -> String {
     serde_json::from_str::<serde_json::Value>(latest)
@@ -136,5 +140,185 @@ pub(crate) fn handle_status_command(job_id: &Option<String>, rm: bool, all: bool
                 }
             }
         }
+    }
+}
+
+pub(crate) async fn watch_job(job_id: &str) -> Result<()> {
+    let log = commands::jobs::log_path(job_id);
+    if !log.exists() {
+        return Err(anyhow!("job '{}' not found", job_id));
+    }
+
+    let json = is_json_mode();
+    let mut offset = 0u64;
+    let mut buffer = String::new();
+    let signal = tokio::signal::ctrl_c();
+    tokio::pin!(signal);
+
+    loop {
+        let new = read_new_lines(&log, offset, &mut buffer)?;
+        offset = new.new_offset;
+        for line in new.lines {
+            print_log_line(&line, json);
+            if is_terminal_event(&line) {
+                return Ok(());
+            }
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(200)) => {},
+            _ = &mut signal => {
+                if !json {
+                    eprintln!();
+                    eprintln!("(watch interrupted; job continues in background)");
+                }
+                return Ok(());
+            }
+        }
+    }
+}
+
+struct NewLines {
+    lines: Vec<String>,
+    new_offset: u64,
+}
+
+fn read_new_lines(path: &Path, from: u64, scratch: &mut String) -> Result<NewLines> {
+    let mut f = std::fs::File::open(path)?;
+    let len = f.metadata()?.len();
+    if len <= from {
+        return Ok(NewLines {
+            lines: Vec::new(),
+            new_offset: from,
+        });
+    }
+    f.seek(SeekFrom::Start(from))?;
+    scratch.clear();
+    f.read_to_string(scratch)?;
+    let mut lines = Vec::new();
+    let mut consumed = from;
+    let mut last_nl = 0;
+    for (i, ch) in scratch.char_indices() {
+        if ch == '\n' {
+            let line = scratch[last_nl..i].trim().to_string();
+            if !line.is_empty() {
+                lines.push(line);
+            }
+            last_nl = i + 1;
+            consumed = from + last_nl as u64;
+        }
+    }
+    Ok(NewLines {
+        lines,
+        new_offset: consumed,
+    })
+}
+
+fn print_log_line(line: &str, json: bool) {
+    if json {
+        println!("{line}");
+        return;
+    }
+    let v: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => {
+            println!("{line}");
+            return;
+        }
+    };
+    let ty = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    match ty {
+        "progress" => {
+            let pct = v.get("percent").and_then(|p| p.as_f64()).unwrap_or(0.0);
+            let bytes_done = v.get("bytes_done").and_then(|n| n.as_u64()).unwrap_or(0);
+            let bytes_total = v.get("bytes_total").and_then(|n| n.as_u64()).unwrap_or(0);
+            let speed = v.get("speed_bps").and_then(|n| n.as_u64()).unwrap_or(0);
+            let file = v.get("file").and_then(|s| s.as_str()).unwrap_or("");
+            println!(
+                "{:>5.1}%  {} / {}  {}/s  {}",
+                pct,
+                crate::ui::utils::format_bytes(bytes_done as f64),
+                crate::ui::utils::format_bytes(bytes_total as f64),
+                crate::ui::utils::format_bytes(speed as f64),
+                file
+            );
+        }
+        "result" => {
+            let status = v.get("status").and_then(|s| s.as_str()).unwrap_or("?");
+            let duration = v
+                .get("duration_secs")
+                .and_then(|n| n.as_f64())
+                .unwrap_or(0.0);
+            let bytes = v.get("bytes_total").and_then(|n| n.as_u64()).unwrap_or(0);
+            let err = v.get("error").and_then(|s| s.as_str());
+            match (status, err) {
+                ("success", _) => println!(
+                    "Done: {} in {:.1}s",
+                    crate::ui::utils::format_bytes(bytes as f64),
+                    duration
+                ),
+                (_, Some(msg)) => println!("Error: {} (after {:.1}s)", msg, duration),
+                (s, None) => println!("Result: {} (after {:.1}s)", s, duration),
+            }
+        }
+        _ => {
+            // Header line ({"job_id":..,"pid":..,"log":..}) and unknown types pass through.
+            if let Some(jid) = v.get("job_id").and_then(|s| s.as_str()) {
+                println!(
+                    "Job {} (pid {})",
+                    jid,
+                    v.get("pid").and_then(|p| p.as_u64()).unwrap_or(0)
+                );
+            } else {
+                println!("{line}");
+            }
+        }
+    }
+}
+
+fn is_terminal_event(line: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|v| {
+            v.get("type")
+                .and_then(|t| t.as_str())
+                .map(|t| t == "result")
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_terminal_event_recognises_result() {
+        assert!(is_terminal_event(
+            "{\"type\":\"result\",\"status\":\"success\"}"
+        ));
+        assert!(!is_terminal_event(
+            "{\"type\":\"progress\",\"percent\":50.0}"
+        ));
+        assert!(!is_terminal_event("{\"job_id\":\"abc\"}"));
+        assert!(!is_terminal_event("not json"));
+    }
+
+    #[test]
+    fn read_new_lines_returns_appended_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("log.jsonl");
+        std::fs::write(&p, "{\"type\":\"progress\"}\n{\"type\":\"result\"}\n").unwrap();
+        let mut buf = String::new();
+        let r1 = read_new_lines(&p, 0, &mut buf).unwrap();
+        assert_eq!(r1.lines.len(), 2);
+        let r2 = read_new_lines(&p, r1.new_offset, &mut buf).unwrap();
+        assert!(r2.lines.is_empty());
+        std::fs::write(
+            &p,
+            "{\"type\":\"progress\"}\n{\"type\":\"result\"}\n{\"type\":\"extra\"}\n",
+        )
+        .unwrap();
+        let r3 = read_new_lines(&p, r1.new_offset, &mut buf).unwrap();
+        assert_eq!(r3.lines.len(), 1);
+        assert!(r3.lines[0].contains("extra"));
     }
 }

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -3,7 +3,10 @@ use crate::config::is_json_mode;
 use anyhow::{anyhow, Result};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+const STARTUP_GRACE: Duration = Duration::from_secs(1);
 
 pub(crate) fn status_detail(latest: &str) -> String {
     serde_json::from_str::<serde_json::Value>(latest)
@@ -145,6 +148,11 @@ pub(crate) fn handle_status_command(job_id: &Option<String>, rm: bool, all: bool
 
 pub(crate) async fn watch_job(job_id: &str) -> Result<()> {
     let log = commands::jobs::log_path(job_id);
+
+    let deadline = Instant::now() + STARTUP_GRACE;
+    while !log.exists() && Instant::now() < deadline {
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
     if !log.exists() {
         return Err(anyhow!("job '{}' not found", job_id));
     }
@@ -152,6 +160,7 @@ pub(crate) async fn watch_job(job_id: &str) -> Result<()> {
     let json = is_json_mode();
     let mut offset = 0u64;
     let mut buffer = String::new();
+    let mut header_pid: Option<u32> = None;
     let signal = tokio::signal::ctrl_c();
     tokio::pin!(signal);
 
@@ -159,13 +168,39 @@ pub(crate) async fn watch_job(job_id: &str) -> Result<()> {
         let new = read_new_lines(&log, offset, &mut buffer)?;
         offset = new.new_offset;
         for line in new.lines {
+            if header_pid.is_none() {
+                header_pid = parse_header_pid(&line);
+            }
             print_log_line(&line, json);
             if is_terminal_event(&line) {
                 return Ok(());
             }
         }
+        if let Some(pid) = header_pid {
+            if !commands::jobs::is_pid_alive(pid) {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "type": "watch",
+                            "status": "writer_dead",
+                            "pid": pid,
+                        })
+                    );
+                } else {
+                    eprintln!(
+                        "Error: job pid {} no longer running and no result event was emitted",
+                        pid
+                    );
+                }
+                return Err(anyhow!(
+                    "job '{}' writer died without emitting a result event",
+                    job_id
+                ));
+            }
+        }
         tokio::select! {
-            _ = tokio::time::sleep(Duration::from_millis(200)) => {},
+            _ = tokio::time::sleep(POLL_INTERVAL) => {},
             _ = &mut signal => {
                 if !json {
                     eprintln!();
@@ -175,6 +210,12 @@ pub(crate) async fn watch_job(job_id: &str) -> Result<()> {
             }
         }
     }
+}
+
+fn parse_header_pid(line: &str) -> Option<u32> {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|v| v.get("pid")?.as_u64().map(|p| p as u32))
 }
 
 struct NewLines {
@@ -300,6 +341,17 @@ mod tests {
         ));
         assert!(!is_terminal_event("{\"job_id\":\"abc\"}"));
         assert!(!is_terminal_event("not json"));
+    }
+
+    #[test]
+    fn parse_header_pid_extracts_pid_field() {
+        assert_eq!(
+            parse_header_pid(r#"{"job_id":"abc","pid":4321,"log":"/x"}"#),
+            Some(4321)
+        );
+        assert_eq!(parse_header_pid(r#"{"job_id":"abc"}"#), None);
+        assert_eq!(parse_header_pid(r#"{"type":"progress"}"#), None);
+        assert_eq!(parse_header_pid("not json"), None);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -319,6 +319,10 @@ pub enum Commands {
         /// Garbage-collect job logs older than the configured retention (7d)
         #[arg(long, conflicts_with_all = ["rm", "all"])]
         gc: bool,
+
+        /// Follow a running job's NDJSON log until its terminal result
+        #[arg(long, requires = "job_id", conflicts_with_all = ["rm", "all", "gc"])]
+        watch: bool,
     },
 
     /// Check for updates and self-update

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,8 +149,16 @@ async fn main() -> Result<()> {
             rm,
             all,
             gc,
+            watch,
         } => {
-            handle_status_command(job_id, *rm, *all, *gc);
+            if *watch {
+                let id = job_id
+                    .as_deref()
+                    .expect("clap requires job_id with --watch");
+                app::status::watch_job(id).await?;
+            } else {
+                handle_status_command(job_id, *rm, *all, *gc);
+            }
         }
         Commands::Init { .. } => handle_init_command(&cli.command)?,
         Commands::Update { check } => {


### PR DESCRIPTION
Closes #110.

## Summary

\`bcmr status <id>\` was one-shot — no way to follow a running transfer's NDJSON events without manually \`tail -f\`'ing the log file. This is the follow-half of #68 (the cleanup half \`--rm\`/\`--gc\` shipped in PR #101).

## What changes

\`\`\`
bcmr status <id> --watch         # pretty-print each line as it lands
bcmr --json status <id> --watch  # raw NDJSON pass-through
\`\`\`

Pretty mode collapses each event class to a single readable line:

\`\`\`
Job d912cf1b2c4 (pid 45766)
 25.0%  250 B / 1000 B  100 B/s  f.bin
 75.0%  750 B / 1000 B  200 B/s  f.bin
Done: 1000 B in 5.0s
\`\`\`

JSON mode passes the log through unchanged (same contract as the file).

## Implementation

- Polls the log file every 200ms; reads only the appended bytes since the last tick.
- Exits on the terminal \`{\"type\":\"result\"}\` event.
- Ctrl-C stops the watcher with a one-line hint that the job continues in the background.
- \`std::fs::File::seek + read_to_string\` from the saved offset; lines split on \`\\n\`. \`read_new_lines\` and \`is_terminal_event\` are unit-tested.

## Clap surface

\`\`\`
--watch    # requires job_id; conflicts with --rm and --gc
\`\`\`

## Out of scope

- \`--kill <id>\` — process signaling subsystem; bigger design surface.
- \`--filter <expr>\` — needs a small query DSL on the listing form.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — 2 new unit tests pass
- [x] CI: existing \`--json\` bg-mode test extended to assert \`Done:\` (pretty) and \`\"type\":\"result\"\` (JSON) arrive via \`--watch\`, plus the two clap-conflict gates
- [x] Live: synthesized log with header + 2 progress + 1 result event renders correctly in both modes