### PR TITLE
feat(ui): surface reflink count in Done line + result event (#112)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -221,6 +221,7 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
             args,
             runner.inc_callback(),
             runner.file_callback(),
+            runner.reflink_callback(),
         )
         .await;
 
@@ -273,6 +274,7 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
                 on_total_update: Box::new(total_cb),
                 on_scan_complete: Box::new(scan_done_cb),
                 on_file_found: Box::new(files_found_cb),
+                on_reflink: Box::new(runner.reflink_callback()),
             },
         )
         .await;
@@ -368,7 +370,8 @@ pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
         }
 
         for src in sources {
-            commands::r#move::move_path(src, dest, args, &excludes, |_| {}, |_, _| {}).await?;
+            commands::r#move::move_path(src, dest, args, &excludes, |_| {}, |_, _| {}, || {})
+                .await?;
         }
 
         if !is_json_mode() {
@@ -398,6 +401,7 @@ pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
             &excludes,
             runner.inc_callback(),
             runner.file_callback(),
+            runner.reflink_callback(),
         )
         .await;
 

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -353,6 +353,7 @@ pub async fn execute_plan<F>(
     cli: &Commands,
     progress_callback: F,
     on_new_file: impl Fn(&str, u64) + Send + Sync + 'static,
+    on_reflink: impl Fn() + Send + Sync + 'static,
 ) -> std::result::Result<(), BcmrError>
 where
     F: Fn(u64) + Send + Sync + Clone + 'static,
@@ -361,6 +362,7 @@ where
     let callback = ProgressCallback {
         callback: progress_callback,
         on_new_file: Arc::new(on_new_file),
+        on_reflink: Arc::new(on_reflink),
     };
 
     for entry in &plan.entries {
@@ -425,10 +427,12 @@ where
 }
 
 type OnNewFileFn = Arc<dyn Fn(&str, u64) + Send + Sync>;
+type OnReflinkFn = Arc<dyn Fn() + Send + Sync>;
 
 pub struct ProgressCallback<F> {
     pub(super) callback: F,
     pub(super) on_new_file: OnNewFileFn,
+    pub(super) on_reflink: OnReflinkFn,
 }
 
 impl<F: Clone> Clone for ProgressCallback<F> {
@@ -436,6 +440,7 @@ impl<F: Clone> Clone for ProgressCallback<F> {
         Self {
             callback: self.callback.clone(),
             on_new_file: Arc::clone(&self.on_new_file),
+            on_reflink: Arc::clone(&self.on_reflink),
         }
     }
 }
@@ -447,6 +452,7 @@ pub async fn copy_path<F>(
     excludes: &[regex::Regex],
     progress_callback: F,
     on_new_file: impl Fn(&str, u64) + Send + Sync + 'static,
+    on_reflink: impl Fn() + Send + Sync + 'static,
 ) -> std::result::Result<(), BcmrError>
 where
     F: Fn(u64) + Send + Sync + Clone + 'static,
@@ -455,6 +461,7 @@ where
     let callback = ProgressCallback {
         callback: progress_callback,
         on_new_file: Arc::new(on_new_file),
+        on_reflink: Arc::new(on_reflink),
     };
 
     if traversal::is_excluded(src, excludes) {

--- a/src/commands/copy/file_copy.rs
+++ b/src/commands/copy/file_copy.rs
@@ -238,6 +238,7 @@ where
     )
     .await?
     {
+        (callback.on_reflink)();
         let ctx = FinalizeCtx {
             write_target: &write_target,
             dst,

--- a/src/commands/copy/pipeline_batch.rs
+++ b/src/commands/copy/pipeline_batch.rs
@@ -24,6 +24,7 @@ pub struct PipelineCallbacks<F: Fn(u64) + Send + Sync> {
     pub on_total_update: BoxCallback,
     pub on_scan_complete: BoxNotify,
     pub on_file_found: BoxCallback,
+    pub on_reflink: BoxNotify,
 }
 
 pub async fn pipeline_copy<F>(
@@ -44,6 +45,7 @@ where
     let callback = ProgressCallback {
         callback: cb.on_progress,
         on_new_file: Arc::from(cb.on_new_file),
+        on_reflink: Arc::from(cb.on_reflink),
     };
     let on_total_update = cb.on_total_update;
     let on_scan_complete = cb.on_scan_complete;

--- a/src/commands/move.rs
+++ b/src/commands/move.rs
@@ -53,6 +53,7 @@ pub async fn move_path<F>(
     excludes: &[regex::Regex],
     progress_callback: F,
     on_new_file: impl Fn(&str, u64) + Send + Sync + 'static + Clone,
+    on_reflink: impl Fn() + Send + Sync + 'static + Clone,
 ) -> std::result::Result<(), BcmrError>
 where
     F: Fn(u64) + Send + Sync + Clone + 'static,
@@ -104,6 +105,7 @@ where
                     excludes,
                     progress_callback.clone(),
                     on_new_file.clone(),
+                    on_reflink.clone(),
                 )
                 .await?;
                 fs::remove_file(src).await?;
@@ -174,6 +176,7 @@ where
                 excludes,
                 progress_callback.clone(),
                 on_new_file.clone(),
+                on_reflink.clone(),
             )
             .await?;
 
@@ -198,6 +201,7 @@ where
                         excludes,
                         progress_callback.clone(),
                         on_new_file.clone(),
+                        on_reflink.clone(),
                     )
                     .await?;
                     fs::remove_dir_all(src).await?;

--- a/src/ui/inline.rs
+++ b/src/ui/inline.rs
@@ -197,6 +197,10 @@ impl ProgressRenderer for InlineProgress {
         self.data.verify_mode = on;
     }
 
+    fn inc_reflink(&mut self) {
+        self.data.reflink_count += 1;
+    }
+
     fn inc_items_processed(&mut self) {
         self.data.items_processed += 1;
         let _ = self.redraw();

--- a/src/ui/json.rs
+++ b/src/ui/json.rs
@@ -84,6 +84,8 @@ struct ResultLine<'a> {
     avg_speed_bps: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     bytes_skipped: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reflink_count: Option<u64>,
     #[serde(skip_serializing_if = "core::ops::Not::not")]
     verified: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -230,6 +232,7 @@ impl ProgressRenderer for JsonProgress {
             duration_secs: elapsed.as_secs_f64(),
             avg_speed_bps: avg_bps,
             bytes_skipped: (self.data.skipped_bytes > 0).then_some(self.data.skipped_bytes),
+            reflink_count: (self.data.reflink_count > 0).then_some(self.data.reflink_count),
             verified: self.data.verify_mode,
             error: None,
         };
@@ -252,6 +255,7 @@ impl ProgressRenderer for JsonProgress {
             duration_secs: elapsed.as_secs_f64(),
             avg_speed_bps: None,
             bytes_skipped: (self.data.skipped_bytes > 0).then_some(self.data.skipped_bytes),
+            reflink_count: (self.data.reflink_count > 0).then_some(self.data.reflink_count),
             verified: self.data.verify_mode,
             error: Some(msg),
         };
@@ -261,5 +265,9 @@ impl ProgressRenderer for JsonProgress {
 
     fn set_verify_mode(&mut self, on: bool) {
         self.data.verify_mode = on;
+    }
+
+    fn inc_reflink(&mut self) {
+        self.data.reflink_count += 1;
     }
 }

--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -29,6 +29,7 @@ pub trait ProgressRenderer: Send {
     fn finish_worker(&mut self, _slot: usize) {}
 
     fn set_verify_mode(&mut self, _on: bool) {}
+    fn inc_reflink(&mut self) {}
 
     fn tick(&mut self) {}
 }
@@ -66,6 +67,10 @@ impl ProgressRenderer for PlainTextProgress {
 
     fn set_verify_mode(&mut self, on: bool) {
         self.data.verify_mode = on;
+    }
+
+    fn inc_reflink(&mut self) {
+        self.data.reflink_count += 1;
     }
 }
 

--- a/src/ui/runner.rs
+++ b/src/ui/runner.rs
@@ -61,6 +61,11 @@ impl ProgressRunner {
         move |n| p.lock().inc_skipped(n)
     }
 
+    pub fn reflink_callback(&self) -> impl Fn() + Send + Sync + Clone + 'static {
+        let p = Arc::clone(&self.progress);
+        move || p.lock().inc_reflink()
+    }
+
     pub fn file_callback(&self) -> impl Fn(&str, u64) + Send + Sync + Clone + 'static {
         let p = Arc::clone(&self.progress);
         move |name, size| p.lock().set_current_file(name, size)

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -62,6 +62,7 @@ pub struct ProgressData {
     pub workers: Vec<WorkerState>,
     pub parallel_total: usize,
     pub verify_mode: bool,
+    pub reflink_count: u64,
 }
 
 impl ProgressData {
@@ -88,6 +89,7 @@ impl ProgressData {
             workers: Vec::new(),
             parallel_total: 0,
             verify_mode: false,
+            reflink_count: 0,
         }
     }
 
@@ -197,6 +199,9 @@ impl ProgressData {
                 format_bytes(self.skipped_bytes as f64)
             ));
         }
+        if self.reflink_count > 0 {
+            line.push_str(&format!(" | reflinked {}", self.reflink_count));
+        }
         if self.verify_mode {
             line.push_str(" | verified");
         }
@@ -301,6 +306,17 @@ mod tests {
             line.contains("30"),
             "expected skipped MiB count, got: {line}"
         );
+    }
+
+    #[test]
+    fn test_done_summary_appends_reflinked_when_count_nonzero() {
+        let mut pd = ProgressData::new(1024);
+        pd.current_bytes = 1024;
+        let plain = pd.done_summary_line();
+        assert!(!plain.contains("reflinked"), "got: {plain}");
+        pd.reflink_count = 3;
+        let with = pd.done_summary_line();
+        assert!(with.contains("reflinked 3"), "got: {with}");
     }
 
     #[test]

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -501,6 +501,10 @@ impl ProgressRenderer for TuiProgress {
         self.data.verify_mode = on;
     }
 
+    fn inc_reflink(&mut self) {
+        self.data.reflink_count += 1;
+    }
+
     fn inc_items_processed(&mut self) {
         self.data.items_processed += 1;
         let _ = self.redraw();


### PR DESCRIPTION
Closes #112 (reflink portion).

## Summary

Continues #76 / #105 / #100. Earlier PRs shipped \`skipped\` bytes and \`verified\`. This adds the **reflink counter** — \`reflink_count\` tracks how many files in the run got CoW-cloned vs fell through to a regular copy. Useful on btrfs / APFS / XFS to confirm reflink is actually happening.

\`\`\`
\$ bcmr copy --plain --reflink force /tmp/a.txt /tmp/b.txt
Done: 6 B in 0.0s | avg 2.05 KiB/s | reflinked 1

\$ bcmr copy --plain -r --reflink force /tmp/src /tmp/dst
Done: 6 B in 0.0s | avg 6.27 KiB/s | reflinked 3
\`\`\`

JSON \`result\` event gains \`reflink_count\` (omitted when zero, so existing log consumers see no schema break).

## Implementation

- \`ProgressData\` gains \`reflink_count: u64\`.
- \`ProgressRenderer::inc_reflink()\` trait method (default no-op).
- \`ProgressRunner::reflink_callback() -> impl Fn()\` for the copy backend to hold.
- \`ProgressCallback\` (per-file callback bundle) gains \`on_reflink: Arc<dyn Fn() + Send + Sync>\`.
- \`copy::execute_plan\`, \`copy::copy_path\`, \`pipeline_copy\`, \`move_path\` take an extra \`on_reflink\` arg threaded from the runner.
- In \`file_copy.rs\`, at the \`try_reflink\` success site, \`(callback.on_reflink)()\` is called before the early return.

## Out of scope (defers other half of #112 close)

The dedup and compress counters from the original issue need fundamentally different instrumentation:

- **dedup_count / dedup_bytes_saved**: CAS-hit hook in the serve protocol path (\`src/commands/remote_copy/serve.rs\` near the existing have-blocks short-circuit). New protocol-level callback, not the per-file callback this PR adds.
- **compress_ratio**: requires raw vs compressed-byte accounting in the wire codec (\`src/core/compress.rs::encode_block\`). Different layer.

Both are well-bounded follow-ups but don't share this PR's reflink-callback shape. If specific use cases come up, open focused issues per counter.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green; 1 new unit test \`test_done_summary_appends_reflinked_when_count_nonzero\`
- [x] Live (macOS APFS): single file \`reflinked 1\`, recursive 3 files \`reflinked 3\`, both \`--reflink force\` and auto modes work
- [x] No CI smoke step for the live counter — Linux runner uses ext4 (no reflink support), so a CI assertion would either flake or just verify zero. Format-correctness is unit-tested.