### PR TITLE
feat: bcmr ls / stat / du / hash for remote inspection (#71)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -356,6 +356,30 @@ pub enum Commands {
         hosts: Vec<String>,
     },
 
+    /// List files under a remote path (host:path)
+    Ls {
+        /// Remote path (host:path or @bookmark)
+        path: PathBuf,
+    },
+
+    /// Show type and size of a remote file or directory
+    Stat {
+        /// Remote path (host:path or @bookmark)
+        path: PathBuf,
+    },
+
+    /// Show recursive size of a remote path (du -sh equivalent)
+    Du {
+        /// Remote path (host:path or @bookmark)
+        path: PathBuf,
+    },
+
+    /// Compute the BLAKE3 hash of a remote file
+    Hash {
+        /// Remote path (host:path or @bookmark)
+        path: PathBuf,
+    },
+
     #[command(hide = true)]
     Serve {
         /// Restrict all paths to this directory (defaults to $HOME)

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -1,0 +1,139 @@
+use crate::core::error::BcmrError;
+use crate::core::remote::{
+    parse_remote_path, remote_file_hash, remote_stat, remote_total_size, RemotePath,
+};
+use crate::ui::utils::format_bytes;
+use anyhow::{anyhow, Result};
+use std::path::Path;
+use tokio::process::Command;
+
+fn require_remote(path: &Path) -> Result<RemotePath> {
+    let s = path.to_string_lossy();
+    let rp = parse_remote_path(&s)
+        .ok_or_else(|| anyhow!("'{}' is not a remote path; use host:path or @bookmark", s))?;
+    rp.reject_unsafe()?;
+    Ok(rp)
+}
+
+async fn resolved(path: &Path) -> Result<RemotePath> {
+    let mut rp = require_remote(path)?;
+    rp.expand_tilde().await?;
+    Ok(rp)
+}
+
+pub async fn ls(path: &Path) -> Result<()> {
+    let rp = resolved(path).await?;
+    let entries = list_shallow(&rp).await?;
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let max_size_width = entries
+        .iter()
+        .map(|(_, size, is_dir)| {
+            if *is_dir {
+                1
+            } else {
+                format_bytes(*size as f64).len()
+            }
+        })
+        .max()
+        .unwrap_or(0);
+    for (name, size, is_dir) in &entries {
+        let kind = if *is_dir { "d" } else { "-" };
+        let size_str = if *is_dir {
+            "-".to_string()
+        } else {
+            format_bytes(*size as f64)
+        };
+        println!("{} {:>w$}  {}", kind, size_str, name, w = max_size_width);
+    }
+    Ok(())
+}
+
+async fn list_shallow(rp: &RemotePath) -> Result<Vec<(String, u64, bool)>> {
+    // Shallow listing: -maxdepth 1 -mindepth 1, suppress perm errors and
+    // ignore find's nonzero exit that triggers when any child is unreadable.
+    let escaped = rp.path.replace('\'', "'\\''");
+    let cmd = format!(
+        "find '{}' -maxdepth 1 -mindepth 1 -printf '%f\\0%s\\0%y\\0' 2>/dev/null; true",
+        escaped
+    );
+    let output = Command::new("ssh")
+        .args([
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            &rp.ssh_target(),
+            &cmd,
+        ])
+        .output()
+        .await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "ssh ls failed for '{}': {}",
+            rp.display(),
+            stderr.trim()
+        ));
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let fields: Vec<&str> = raw.split('\0').collect();
+    let mut entries = Vec::new();
+    let mut i = 0;
+    while i + 2 < fields.len() {
+        let name = fields[i].to_string();
+        let size: u64 = fields[i + 1].parse().unwrap_or(0);
+        let is_dir = fields[i + 2] == "d";
+        i += 3;
+        if name.is_empty() {
+            continue;
+        }
+        entries.push((name, size, is_dir));
+    }
+    entries.sort();
+    Ok(entries)
+}
+
+pub async fn stat(path: &Path) -> Result<()> {
+    let rp = resolved(path).await?;
+    let info = remote_stat(&rp).await.map_err(into_anyhow)?;
+    let kind = if info.is_dir { "directory" } else { "file" };
+    if info.is_dir {
+        println!("{}: {}", rp.display(), kind);
+    } else {
+        println!(
+            "{}: {} ({} bytes, {})",
+            rp.display(),
+            kind,
+            info.size,
+            format_bytes(info.size as f64)
+        );
+    }
+    Ok(())
+}
+
+pub async fn du(path: &Path) -> Result<()> {
+    let rp = resolved(path).await?;
+    let total = remote_total_size(&rp, true).await.map_err(into_anyhow)?;
+    println!("{}\t{}", format_bytes(total as f64), rp.display());
+    Ok(())
+}
+
+pub async fn hash(path: &Path) -> Result<()> {
+    let rp = resolved(path).await?;
+    let info = remote_stat(&rp).await.map_err(into_anyhow)?;
+    if info.is_dir {
+        return Err(anyhow!(
+            "'{}' is a directory; bcmr hash takes a file",
+            rp.display()
+        ));
+    }
+    let hex = remote_file_hash(&rp, None).await.map_err(into_anyhow)?;
+    println!("{}  {}", hex, rp.display());
+    Ok(())
+}
+
+fn into_anyhow(e: BcmrError) -> anyhow::Error {
+    anyhow::anyhow!("{}", e)
+}

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -1,11 +1,11 @@
 use crate::core::error::BcmrError;
 use crate::core::remote::{
-    parse_remote_path, remote_file_hash, remote_stat, remote_total_size, RemotePath,
+    parse_remote_path, remote_file_hash, remote_list_shallow, remote_stat, remote_total_size,
+    RemotePath,
 };
 use crate::ui::utils::format_bytes;
 use anyhow::{anyhow, Result};
 use std::path::Path;
-use tokio::process::Command;
 
 fn require_remote(path: &Path) -> Result<RemotePath> {
     let s = path.to_string_lossy();
@@ -23,10 +23,11 @@ async fn resolved(path: &Path) -> Result<RemotePath> {
 
 pub async fn ls(path: &Path) -> Result<()> {
     let rp = resolved(path).await?;
-    let entries = list_shallow(&rp).await?;
+    let mut entries = remote_list_shallow(&rp).await.map_err(into_anyhow)?;
     if entries.is_empty() {
         return Ok(());
     }
+    entries.sort();
     let max_size_width = entries
         .iter()
         .map(|(_, size, is_dir)| {
@@ -48,51 +49,6 @@ pub async fn ls(path: &Path) -> Result<()> {
         println!("{} {:>w$}  {}", kind, size_str, name, w = max_size_width);
     }
     Ok(())
-}
-
-async fn list_shallow(rp: &RemotePath) -> Result<Vec<(String, u64, bool)>> {
-    // Shallow listing: -maxdepth 1 -mindepth 1, suppress perm errors and
-    // ignore find's nonzero exit that triggers when any child is unreadable.
-    let escaped = rp.path.replace('\'', "'\\''");
-    let cmd = format!(
-        "find '{}' -maxdepth 1 -mindepth 1 -printf '%f\\0%s\\0%y\\0' 2>/dev/null; true",
-        escaped
-    );
-    let output = Command::new("ssh")
-        .args([
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "ConnectTimeout=10",
-            &rp.ssh_target(),
-            &cmd,
-        ])
-        .output()
-        .await?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow!(
-            "ssh ls failed for '{}': {}",
-            rp.display(),
-            stderr.trim()
-        ));
-    }
-    let raw = String::from_utf8_lossy(&output.stdout);
-    let fields: Vec<&str> = raw.split('\0').collect();
-    let mut entries = Vec::new();
-    let mut i = 0;
-    while i + 2 < fields.len() {
-        let name = fields[i].to_string();
-        let size: u64 = fields[i + 1].parse().unwrap_or(0);
-        let is_dir = fields[i + 2] == "d";
-        i += 3;
-        if name.is_empty() {
-            continue;
-        }
-        entries.push((name, size, is_dir));
-    }
-    entries.sort();
-    Ok(entries)
 }
 
 pub async fn stat(path: &Path) -> Result<()> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod copy_strategies;
 pub mod deploy;
 pub mod doctor;
 pub mod init;
+pub mod inspect;
 pub mod jobs;
 pub mod r#move;
 pub mod remote_copy;

--- a/src/core/remote.rs
+++ b/src/core/remote.rs
@@ -9,8 +9,8 @@ pub use attrs::{apply_remote_attrs_locally, preserve_remote_attrs, verify_remote
 #[allow(unused_imports)]
 pub use ops::{
     complete_remote_path, expand_remote_tilde, remote_file_hash, remote_file_size,
-    remote_list_files, remote_path_is_directory, remote_remove, remote_stat, remote_total_size,
-    resolve_remote_home, validate_ssh_connection,
+    remote_list_files, remote_list_shallow, remote_path_is_directory, remote_remove, remote_stat,
+    remote_total_size, resolve_remote_home, validate_ssh_connection,
 };
 pub use resume::{check_resume_state, ResumeDecision};
 #[allow(unused_imports)]

--- a/src/core/remote/ops.rs
+++ b/src/core/remote/ops.rs
@@ -136,6 +136,39 @@ pub async fn remote_list_files(remote: &RemotePath) -> Result<Vec<(String, u64, 
     Ok(entries)
 }
 
+pub async fn remote_list_shallow(
+    remote: &RemotePath,
+) -> Result<Vec<(String, u64, bool)>, BcmrError> {
+    let escaped = shell_escape(&remote.path);
+    let cmd = format!(
+        "find '{}' -maxdepth 1 -mindepth 1 -printf '%f\\0%s\\0%y\\0' 2>/dev/null; true",
+        escaped
+    );
+    let output = ssh_command(&remote.ssh_target()).arg(cmd).output().await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(BcmrError::InvalidInput(ssh_error_message(
+            &stderr,
+            &format!("Cannot list remote directory '{}'", remote),
+        )));
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let fields: Vec<&str> = raw.split('\0').collect();
+    let mut entries = Vec::new();
+    let mut i = 0;
+    while i + 3 <= fields.len() {
+        let name = fields[i].to_string();
+        let size: u64 = fields[i + 1].parse().unwrap_or(0);
+        let is_dir = fields[i + 2] == "d";
+        i += 3;
+        if name.is_empty() {
+            continue;
+        }
+        entries.push((name, size, is_dir));
+    }
+    Ok(entries)
+}
+
 pub async fn remote_file_hash(
     remote: &RemotePath,
     limit: Option<u64>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,10 @@ async fn main() -> Result<()> {
         Commands::Doctor { hosts } => {
             commands::doctor::run(hosts, is_json_mode()).await?;
         }
+        Commands::Ls { path } => commands::inspect::ls(path).await?,
+        Commands::Stat { path } => commands::inspect::stat(path).await?,
+        Commands::Du { path } => commands::inspect::du(path).await?,
+        Commands::Hash { path } => commands::inspect::hash(path).await?,
         Commands::CompleteRemote { partial } => {
             for entry in crate::core::remote::complete_remote_path(partial).await {
                 println!("{}", entry);


### PR DESCRIPTION
Closes #71 (4 of 5 verbs from the original ask; flag/option set scoped to v1).

## Summary

Four user-facing inspection subcommands that wrap existing serve-protocol / ssh-shell helpers:

| Command | Purpose | Output |
|---|---|---|
| `bcmr ls <host:path>` | shallow listing (one-level, like `ls`) | type + size + name per line |
| `bcmr stat <host:path>` | type + size of one file/dir | `<path>: file (26 bytes, 26 B)` |
| `bcmr du <host:path>` | recursive total size (`du -sh` equivalent) | `<size>\t<path>` |
| `bcmr hash <host:path>` | BLAKE3 of a remote file | `<hex>  <path>` |

```
$ bcmr stat 4090:/etc/hostname
4090:/etc/hostname: file (26 bytes, 26 B)

$ bcmr hash 4090:/etc/hostname
7f8616e95261311db2d385fcf7020722bbc110f3ec4516d26a4fb7e4bde770b4  4090:/etc/hostname

$ bcmr ls 4090:/tmp
d          -  .ICE-unix
d          -  .X11-unix
-  33.67 KiB  some-file.dat
...

$ bcmr du 4090:/etc/hostname
26 B	4090:/etc/hostname
```

## Implementation

Each subcommand accepts a single `PathBuf` positional, parsed via `parse_remote_path` (so `@bookmark` aliases work). Errors clearly when the path is local-only.

All four reuse helpers in `src/core/remote/ops.rs` (`remote_stat`, `remote_total_size`, `remote_file_hash`, plus a new `remote_list_shallow`). Every SSH call goes through `ssh_command()`, which sets `ControlMaster=auto` / `ControlPersist=300`, so back-to-back inspect calls reuse one TCP/auth handshake per host.

`bcmr ls` uses a shallow `find -maxdepth 1 -mindepth 1` rather than the recursive `remote_list_files` — the recursive variant exits nonzero whenever any subdir is unreadable (typical on `/tmp`, `/etc`).

## Scope of v1

This PR delivers the four verbs from #71. Flag/option set is intentionally minimal:

- **`-l` / `-R`** for `ls`, **`--top N`** / **`-h`** for `du`, **mode/mtime/owner** for `stat`, **`-r` (tree hash)** for `hash`, **`--json`** uniformly: deferred. The plain output is greppable and `bcmr du` already prints human-readable sizes; everything else is additive UX.
- **`bcmr cat <host:path>`** (the fifth verb): streaming a remote file to stdout doesn't fit the existing `transfer.rs` surface. A focused PR can add a remote-read-to-stdout path on top of the serve protocol's `get` message.

Each is straightforward to add on top of this scaffolding without breaking the v1 API.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features test-support -- -D warnings` clean
- [x] `cargo test --features test-support` — full suite green; no new unit tests (each subcommand is a thin shim over already-tested helpers)
- [x] Live: `bcmr stat 4090:/etc/hostname`, `bcmr hash 4090:/etc/hostname`, `bcmr ls 4090:/etc` (shallow, survives perm errors), `bcmr du 4090:/etc/hostname` all produce expected output
- [x] Local path rejected: `bcmr stat /tmp` → "is not a remote path; use host:path or @bookmark"