### PR TITLE
feat(copy): --to <DEST> for fan-out copy to multiple targets (#80)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,39 @@ jobs:
           test -s /tmp/bcmr-fanout/a.txt || { echo "FAIL: a.txt should still copy"; exit 1; }
           test -s /tmp/bcmr-fanout/b.txt || { echo "FAIL: b.txt should still copy"; exit 1; }
 
+          # Single positional with no --to and no dest must error, not silently no-op.
+          if cargo run --quiet -- copy --plain /tmp/bcmr-fanout/src.txt 2>/dev/null; then
+            echo "FAIL: copy with single positional and no --to should error"; exit 1;
+          fi
+
+          # --quiet suppresses the per-target progress header on stderr.
+          rm -f /tmp/bcmr-fanout/{a,b}.txt
+          q=$(cargo run --quiet -- copy --quiet /tmp/bcmr-fanout/src.txt \
+                --to /tmp/bcmr-fanout/a.txt --to /tmp/bcmr-fanout/b.txt 2>&1 1>/dev/null)
+          if echo "$q" | grep -q "→ copying to"; then
+            echo "FAIL: --quiet should suppress per-target header"; exit 1;
+          fi
+
+          # move --to fans out and removes sources only when all targets succeed.
+          echo "move-content" > /tmp/bcmr-fanout/mv-src.txt
+          rm -f /tmp/bcmr-fanout/m{1,2}.txt
+          cargo run --quiet -- move --plain /tmp/bcmr-fanout/mv-src.txt \
+            --to /tmp/bcmr-fanout/m1.txt --to /tmp/bcmr-fanout/m2.txt
+          test -s /tmp/bcmr-fanout/m1.txt && test -s /tmp/bcmr-fanout/m2.txt \
+            || { echo "FAIL: move fan-out targets missing"; exit 1; }
+          test ! -e /tmp/bcmr-fanout/mv-src.txt \
+            || { echo "FAIL: move source should be removed after fan-out"; exit 1; }
+
+          # move --to with one failing target preserves the source.
+          echo "preserve-content" > /tmp/bcmr-fanout/mv2-src.txt
+          if cargo run --quiet -- move --plain /tmp/bcmr-fanout/mv2-src.txt \
+              --to /tmp/bcmr-fanout/keep1.txt \
+              --to /nonexistent/dir/x.txt 2>/dev/null; then
+            echo "FAIL: move fan-out should fail when a target fails"; exit 1;
+          fi
+          test -s /tmp/bcmr-fanout/mv2-src.txt \
+            || { echo "FAIL: move source must be preserved when fan-out fails"; exit 1; }
+
           rm -rf /tmp/bcmr-fanout
           echo "Multi-dest fan-out tests passed"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,38 @@ jobs:
 
           echo "Copy tests passed"
 
+      - name: Test multi-destination fan-out (--to)
+        shell: bash
+        run: |
+          mkdir -p /tmp/bcmr-fanout
+          echo "fanout-content" > /tmp/bcmr-fanout/src.txt
+          rm -f /tmp/bcmr-fanout/a.txt /tmp/bcmr-fanout/b.txt /tmp/bcmr-fanout/c.txt
+
+          # All three dests get the file.
+          cargo run --quiet -- copy --plain /tmp/bcmr-fanout/src.txt \
+            --to /tmp/bcmr-fanout/a.txt \
+            --to /tmp/bcmr-fanout/b.txt \
+            --to /tmp/bcmr-fanout/c.txt
+          for d in a b c; do
+            test -s "/tmp/bcmr-fanout/$d.txt" || { echo "FAIL: /tmp/bcmr-fanout/$d.txt missing"; exit 1; }
+            diff /tmp/bcmr-fanout/src.txt /tmp/bcmr-fanout/$d.txt
+          done
+
+          # One dest fails, others succeed; exit code reflects failures.
+          rm -f /tmp/bcmr-fanout/{a,b}.txt
+          if cargo run --quiet -- copy --plain /tmp/bcmr-fanout/src.txt \
+              --to /tmp/bcmr-fanout/a.txt \
+              --to /nonexistent/dir/x.txt \
+              --to /tmp/bcmr-fanout/b.txt 2>/dev/null; then
+            echo "FAIL: expected non-zero when one dest fails"
+            exit 1
+          fi
+          test -s /tmp/bcmr-fanout/a.txt || { echo "FAIL: a.txt should still copy"; exit 1; }
+          test -s /tmp/bcmr-fanout/b.txt || { echo "FAIL: b.txt should still copy"; exit 1; }
+
+          rm -rf /tmp/bcmr-fanout
+          echo "Multi-dest fan-out tests passed"
+
       - name: Test copy with verify
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,7 @@ jobs:
           echo "Copy tests passed"
 
       - name: Test multi-destination fan-out (--to)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           mkdir -p /tmp/bcmr-fanout

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -107,10 +107,48 @@ fn check_basename_collisions(sources: &[std::path::PathBuf], force: bool) -> Res
 }
 
 pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
+    let to = args
+        .copy_move_args()
+        .map(|a| a.to.as_slice())
+        .unwrap_or(&[]);
+    if to.is_empty() {
+        return handle_copy_one(args, None).await;
+    }
+
+    let mut failures = 0usize;
+    for dest in to {
+        if !is_json_mode() {
+            eprintln!("→ copying to {}", dest.display());
+        }
+        if let Err(e) = handle_copy_one(args, Some(dest)).await {
+            failures += 1;
+            eprintln!("Error copying to {}: {}", dest.display(), e);
+        }
+    }
+    if failures > 0 {
+        bail!("{} of {} fan-out targets failed", failures, to.len());
+    }
+    Ok(())
+}
+
+async fn handle_copy_one(args: &Commands, dest_override: Option<&std::path::Path>) -> Result<()> {
     use crate::core::remote::parse_remote_path;
 
     let excludes = args.compile_excludes()?;
-    let (sources, dest) = args.get_sources_and_dest().map_err(anyhow::Error::msg)?;
+    let (sources, dest_buf): (&[std::path::PathBuf], std::path::PathBuf) = match dest_override {
+        Some(d) => {
+            let s = args
+                .copy_move_args()
+                .map(|a| a.paths.as_slice())
+                .unwrap_or(&[]);
+            (s, d.to_path_buf())
+        }
+        None => {
+            let (s, d) = args.get_sources_and_dest().map_err(anyhow::Error::msg)?;
+            (s, d.clone())
+        }
+    };
+    let dest: &std::path::Path = dest_buf.as_path();
 
     if let Some(mode) = args.get_reflink_mode() {
         validate_mode(&mode, "reflink")?;

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -107,17 +107,20 @@ fn check_basename_collisions(sources: &[std::path::PathBuf], force: bool) -> Res
 }
 
 pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
-    let to = args
+    let cm = args
         .copy_move_args()
-        .map(|a| a.to.as_slice())
-        .unwrap_or(&[]);
-    if to.is_empty() {
+        .ok_or_else(|| anyhow::anyhow!("copy requires copy/move args"))?;
+
+    if cm.to.is_empty() {
+        if cm.paths.len() < 2 {
+            bail!("missing destination — pass at least <SRC> <DEST> or use --to <DEST>");
+        }
         return handle_copy_one(args, None).await;
     }
 
     let mut failures = 0usize;
-    for dest in to {
-        if !is_json_mode() {
+    for dest in &cm.to {
+        if !is_json_mode() && !args.is_quiet() {
             eprintln!("→ copying to {}", dest.display());
         }
         if let Err(e) = handle_copy_one(args, Some(dest)).await {
@@ -126,7 +129,7 @@ pub(crate) async fn handle_copy_command(args: &Commands) -> Result<()> {
         }
     }
     if failures > 0 {
-        bail!("{} of {} fan-out targets failed", failures, to.len());
+        bail!("{} of {} fan-out targets failed", failures, cm.to.len());
     }
     Ok(())
 }
@@ -324,6 +327,62 @@ async fn handle_copy_one(args: &Commands, dest_override: Option<&std::path::Path
 }
 
 pub(crate) async fn handle_move_command(args: &Commands) -> Result<()> {
+    use crate::core::remote::{parse_remote_path, remote_remove};
+
+    let cm = args
+        .copy_move_args()
+        .ok_or_else(|| anyhow::anyhow!("move requires copy/move args"))?;
+
+    if cm.to.is_empty() {
+        if cm.paths.len() < 2 {
+            bail!("missing destination — pass at least <SRC> <DEST> or use --to <DEST>");
+        }
+        return handle_move_one(args).await;
+    }
+
+    let mut failures = 0usize;
+    for dest in &cm.to {
+        if !is_json_mode() && !args.is_quiet() {
+            eprintln!("→ moving to {}", dest.display());
+        }
+        if let Err(e) = handle_copy_one(args, Some(dest)).await {
+            failures += 1;
+            eprintln!("Error moving to {}: {}", dest.display(), e);
+        }
+    }
+    if failures > 0 {
+        bail!(
+            "{} of {} fan-out targets failed; sources preserved",
+            failures,
+            cm.to.len()
+        );
+    }
+
+    let recursive = args.is_recursive();
+    let verbose = args.is_verbose() && !is_json_mode();
+    for src in &cm.paths {
+        let s = src.to_string_lossy();
+        if let Some(remote_src) = parse_remote_path(&s) {
+            remote_remove(&remote_src, recursive, false, false).await?;
+            if verbose {
+                println!("removed source {}", remote_src.display());
+            }
+        } else {
+            let md = src.symlink_metadata()?;
+            if md.is_dir() {
+                tokio::fs::remove_dir_all(src).await?;
+            } else {
+                tokio::fs::remove_file(src).await?;
+            }
+            if verbose {
+                println!("removed source '{}'", src.display());
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn handle_move_one(args: &Commands) -> Result<()> {
     use crate::core::remote::parse_remote_path;
 
     let excludes = args.compile_excludes()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,9 +159,16 @@ impl std::fmt::Display for Shell {
 
 #[derive(Args, Debug)]
 pub struct CopyMoveArgs {
-    /// Source files and destination directory (last argument is the destination)
-    #[arg(required = true, num_args = 2..)]
+    /// Source files and destination directory (last argument is the destination,
+    /// unless --to is given — then all positionals are sources)
+    #[arg(required = true, num_args = 1..)]
     pub paths: Vec<PathBuf>,
+
+    /// Fan-out destination (repeatable). Each --to is an additional copy target;
+    /// all positional paths are sources. Errors are per-target (one failure does
+    /// not abort the others).
+    #[arg(long = "to", value_name = "DEST")]
+    pub to: Vec<PathBuf>,
 
     /// Recursively process directories
     #[arg(short, long)]
@@ -460,7 +467,7 @@ pub enum TestMode {
 }
 
 impl Commands {
-    fn copy_move_args(&self) -> Option<&CopyMoveArgs> {
+    pub fn copy_move_args(&self) -> Option<&CopyMoveArgs> {
         match self {
             Commands::Copy { args, .. } | Commands::Move { args, .. } => Some(args),
             _ => None,
@@ -727,6 +734,7 @@ mod tests {
     fn test_args(paths: Vec<PathBuf>) -> CopyMoveArgs {
         CopyMoveArgs {
             paths,
+            to: Vec::new(),
             recursive: false,
             preserve: false,
             force: false,


### PR DESCRIPTION
Closes #80.

## Summary

```
bcmr copy file --to host1:dst --to host2:dst --to host3:dst
bcmr move file --to host1:dst --to host2:dst   # fans out, then removes source
```

Fans the same source set out to each `--to` target. Implementation is serial — one full copy per destination, which keeps progress reporting straightforward (each target shows its own Done line) and per-target failure isolation simple.

## Semantics

- When `--to` is given, **all positionals are sources** — the existing "last positional is dest" shorthand turns off.
- Without `--to`: existing behaviour unchanged.
- **Per-target failure isolation**: one target failing does not abort the others. Final exit code is `1` if any target failed, with a `N of M fan-out targets failed` summary on stderr.
- **`bcmr move --to`**: copies to every target, then removes the original — but only if every target succeeded. If any target fails, the source is preserved.
- `--quiet` suppresses the per-target `→ copying to` / `→ moving to` header (errors still print to stderr).
- `bcmr copy <one-path>` (no `--to`, no destination) now errors `missing destination — pass at least <SRC> <DEST> or use --to <DEST>` rather than silently doing nothing.

```
$ bcmr copy --plain file.txt --to /tmp/a.txt --to /tmp/b.txt --to /no/such/dir/x.txt
→ copying to /tmp/a.txt
Done: 6 B in 0.0s | avg 9 KiB/s
→ copying to /tmp/b.txt
Done: 6 B in 0.0s | avg 18 KiB/s
→ copying to /no/such/dir/x.txt
Error copying to /no/such/dir/x.txt: IO error: No such file or directory
Error: 1 of 3 fan-out targets failed
$ echo $?
1
```

## Choices

**Serial over parallel.** Parallel fan-out needs careful progress aggregation across N concurrent transfers and adds dependency on tokio::JoinSet timing. Serial covers the actual use case (backup to multiple hosts) and keeps the mental model simple. Open a focused issue if/when a real workload demands parallel.

**`--to <DEST>` over the issue's `-- host1 host2 host3` trailing-arg syntax.** clap's support for trailing varargs alongside required positionals is fragile, and the flag form matches the rest of bcmr's style.

**Source-read-once tee fan-out is deferred.** Issue #80 frames the win as "the source is read once and streamed through a tee," vs the shell loop that re-reads N times. This PR ships the user-facing surface (one command, per-target failure isolation, `--quiet`-aware reporting) on top of N sequential reads. The streaming-tee engine — splitting plan execution over a single source iterator and N concurrent destination sinks — is a follow-up; tracked locally and worth a focused issue if a workload needs it before then.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features test-support -- -D warnings` clean
- [x] `cargo test --features test-support` — full suite green
- [x] CI smoke covers: 3-way fan-out, single-failure isolation, --quiet header suppression, missing-dest error, move fan-out + source removal, move fan-out preserves source on partial failure