### PR TITLE
feat(config): per-host default flags and named profiles (#111)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,40 @@ jobs:
           rm -rf "$tmp"
           echo "Path bookmark tests passed"
 
+      - name: Test profile + per-host default args
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          tmp=$(mktemp -d)
+          cat > "$tmp/cfg.toml" <<EOF
+          [profile.verify]
+          default_args = ["-V"]
+          EOF
+          echo "profile-test" > "$tmp/src.txt"
+
+          # Without profile: no 'verified' suffix.
+          out_no=$(cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" "$tmp/no.txt" 2>&1)
+          if echo "$out_no" | grep -q "verified"; then
+            echo "FAIL: 'verified' should not appear without profile"; exit 1;
+          fi
+
+          # --profile: 'verified' appears (profile injects -V).
+          out_p=$(cargo run --quiet -- --config "$tmp/cfg.toml" --profile verify copy --plain "$tmp/src.txt" "$tmp/p.txt" 2>&1)
+          echo "$out_p" | grep -q "verified" || { echo "FAIL: --profile verify should inject -V"; exit 1; }
+
+          # BCMR_PROFILE env: same.
+          out_e=$(BCMR_PROFILE=verify cargo run --quiet -- --config "$tmp/cfg.toml" copy --plain "$tmp/src.txt" "$tmp/e.txt" 2>&1)
+          echo "$out_e" | grep -q "verified" || { echo "FAIL: BCMR_PROFILE should inject -V"; exit 1; }
+
+          # Unknown profile: silent no-op.
+          out_u=$(cargo run --quiet -- --config "$tmp/cfg.toml" --profile missing copy --plain "$tmp/src.txt" "$tmp/u.txt" 2>&1)
+          if echo "$out_u" | grep -q "verified"; then
+            echo "FAIL: unknown profile should not inject anything"; exit 1;
+          fi
+
+          rm -rf "$tmp"
+          echo "Profile defaults tests passed"
+
       - name: Test exclude patterns
         shell: bash
         run: |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,6 +159,49 @@ bcmr copy report.pdf  @backup/today/  # → nas:/backups/today/
 
 Aliases work in every position that accepts a path: source list, destination, `bcmr check`, `bcmr remove`.
 
+## Per-Host Default Flags
+
+Apply a fixed set of flags whenever a transfer involves a particular host:
+
+```toml
+[host."lab"]
+default_args = ["-p", "--compress", "zstd", "--reflink", "force"]
+
+[host."slow_link"]
+default_args = ["--bwlimit", "200K"]
+```
+
+```sh
+bcmr copy ./project/ lab:dst/
+# resolves to: bcmr copy -p --compress zstd --reflink force ./project/ lab:dst/
+```
+
+The host name matched is whatever appears in the `host:` portion of any source or destination argument (first one found wins). Explicit CLI flags appear after the injected defaults, so a user-typed `--compress none` overrides a host's `default_args = ["--compress", "zstd"]`.
+
+## Profiles
+
+Named bundles activated by `--profile <name>` or `BCMR_PROFILE=<name>`:
+
+```toml
+[profile.work]
+default_args = ["-p", "-V"]
+
+[profile.home]
+default_args = ["-p"]
+```
+
+```sh
+bcmr --profile work copy ./report.pdf host:dst/
+# resolves to: bcmr copy -p -V ./report.pdf host:dst/
+
+BCMR_PROFILE=home bcmr copy ./report.pdf host:dst/
+# resolves to: bcmr copy -p ./report.pdf host:dst/
+```
+
+**Precedence (left wins):** `explicit user flags > host defaults > profile defaults > built-in defaults`. The injection ordering is `profile, host, user`, all left-to-right; clap parses earlier-then-later, so user flags win.
+
+Unknown `--profile <name>` (no matching `[profile.<name>]` table) is a silent no-op — the rest of the command runs unchanged.
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/src/app/argv_inject.rs
+++ b/src/app/argv_inject.rs
@@ -4,25 +4,24 @@ use crate::core::remote::parse_remote_path;
 const SUBCOMMANDS_THAT_TAKE_DEFAULTS: &[&str] = &["copy", "move", "check", "remove"];
 
 pub fn inject_defaults(argv: Vec<String>, config: &Config) -> Vec<String> {
+    let profile_name = profile_from_argv_or_env(&argv);
+    let argv = strip_profile_flag(argv);
+
     let Some(sub_idx) = find_subcommand(&argv) else {
         return argv;
     };
 
-    let profile_name = profile_from_argv_or_env(&argv);
     let profile_args: Vec<String> = profile_name
         .as_deref()
         .and_then(|n| config.profile.get(n))
         .map(|p| p.default_args.clone())
         .unwrap_or_default();
 
-    let host_args: Vec<String> = first_matching_host_args(&argv[sub_idx..], config);
+    let host_args: Vec<String> = first_matching_host_args(&argv[sub_idx + 1..], config);
 
     if profile_args.is_empty() && host_args.is_empty() {
-        return strip_profile_flag(argv);
+        return argv;
     }
-
-    let argv = strip_profile_flag(argv);
-    let sub_idx = find_subcommand(&argv).expect("subcommand must still be present");
 
     let mut out = Vec::with_capacity(argv.len() + profile_args.len() + host_args.len());
     out.extend(argv[..=sub_idx].iter().cloned());
@@ -74,7 +73,15 @@ fn first_matching_host_args(after_sub: &[String], config: &Config) -> Vec<String
         return Vec::new();
     }
     for token in after_sub {
-        let Some(rp) = parse_remote_path(token) else {
+        let candidate: &str =
+            if let Some(eq) = token.strip_prefix("--").and_then(|s| s.split_once('=')) {
+                eq.1
+            } else if token.starts_with('-') {
+                continue;
+            } else {
+                token
+            };
+        let Some(rp) = parse_remote_path(candidate) else {
             continue;
         };
         if let Some(defaults) = config.host.get(&rp.host) {
@@ -180,5 +187,37 @@ mod tests {
         let cfg = cfg_with(&[("lab", &["-V"])], &[]);
         let argv = s(&["bcmr", "doctor", "lab"]);
         assert_eq!(inject_defaults(argv.clone(), &cfg), argv);
+    }
+
+    #[test]
+    fn profile_stripped_on_non_defaulting_subcommand() {
+        let cfg = cfg_with(&[], &[("work", &["-V"])]);
+        let argv = s(&["bcmr", "--profile", "work", "doctor"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(out, s(&["bcmr", "doctor"]));
+    }
+
+    #[test]
+    fn profile_value_as_subcommand_no_panic() {
+        let cfg = cfg_with(&[], &[("copy", &["-V"])]);
+        let argv = s(&["bcmr", "--profile", "copy", "x", "dst"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(out, s(&["bcmr", "x", "dst"]));
+    }
+
+    #[test]
+    fn host_default_via_to_equals_form() {
+        let cfg = cfg_with(&[("lab", &["-p"])], &[]);
+        let argv = s(&["bcmr", "copy", "src", "--to=lab:dst/"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(out, s(&["bcmr", "copy", "-p", "src", "--to=lab:dst/"]));
+    }
+
+    #[test]
+    fn flag_name_not_treated_as_host() {
+        let cfg = cfg_with(&[("--to", &["BUG"])], &[]);
+        let argv = s(&["bcmr", "copy", "src", "--to=other:dst"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(out, s(&["bcmr", "copy", "src", "--to=other:dst"]));
     }
 }

--- a/src/app/argv_inject.rs
+++ b/src/app/argv_inject.rs
@@ -1,0 +1,184 @@
+use crate::config::Config;
+use crate::core::remote::parse_remote_path;
+
+const SUBCOMMANDS_THAT_TAKE_DEFAULTS: &[&str] = &["copy", "move", "check", "remove"];
+
+pub fn inject_defaults(argv: Vec<String>, config: &Config) -> Vec<String> {
+    let Some(sub_idx) = find_subcommand(&argv) else {
+        return argv;
+    };
+
+    let profile_name = profile_from_argv_or_env(&argv);
+    let profile_args: Vec<String> = profile_name
+        .as_deref()
+        .and_then(|n| config.profile.get(n))
+        .map(|p| p.default_args.clone())
+        .unwrap_or_default();
+
+    let host_args: Vec<String> = first_matching_host_args(&argv[sub_idx..], config);
+
+    if profile_args.is_empty() && host_args.is_empty() {
+        return strip_profile_flag(argv);
+    }
+
+    let argv = strip_profile_flag(argv);
+    let sub_idx = find_subcommand(&argv).expect("subcommand must still be present");
+
+    let mut out = Vec::with_capacity(argv.len() + profile_args.len() + host_args.len());
+    out.extend(argv[..=sub_idx].iter().cloned());
+    out.extend(profile_args);
+    out.extend(host_args);
+    out.extend(argv[sub_idx + 1..].iter().cloned());
+    out
+}
+
+fn find_subcommand(argv: &[String]) -> Option<usize> {
+    argv.iter()
+        .position(|s| SUBCOMMANDS_THAT_TAKE_DEFAULTS.contains(&s.as_str()))
+}
+
+fn profile_from_argv_or_env(argv: &[String]) -> Option<String> {
+    let mut iter = argv.iter().peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--profile" {
+            return iter.next().cloned();
+        }
+        if let Some(rest) = arg.strip_prefix("--profile=") {
+            return Some(rest.to_string());
+        }
+    }
+    std::env::var("BCMR_PROFILE").ok().filter(|s| !s.is_empty())
+}
+
+fn strip_profile_flag(argv: Vec<String>) -> Vec<String> {
+    let mut out = Vec::with_capacity(argv.len());
+    let mut i = 0;
+    while i < argv.len() {
+        let a = &argv[i];
+        if a == "--profile" {
+            i += 2;
+            continue;
+        }
+        if a.starts_with("--profile=") {
+            i += 1;
+            continue;
+        }
+        out.push(a.clone());
+        i += 1;
+    }
+    out
+}
+
+fn first_matching_host_args(after_sub: &[String], config: &Config) -> Vec<String> {
+    if config.host.is_empty() {
+        return Vec::new();
+    }
+    for token in after_sub {
+        let Some(rp) = parse_remote_path(token) else {
+            continue;
+        };
+        if let Some(defaults) = config.host.get(&rp.host) {
+            return defaults.default_args.clone();
+        }
+    }
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{HostDefaults, ProfileDefaults};
+
+    fn cfg_with(hosts: &[(&str, &[&str])], profiles: &[(&str, &[&str])]) -> Config {
+        let mut c = Config::default();
+        for (name, args) in hosts {
+            c.host.insert(
+                (*name).into(),
+                HostDefaults {
+                    default_args: args.iter().map(|s| s.to_string()).collect(),
+                },
+            );
+        }
+        for (name, args) in profiles {
+            c.profile.insert(
+                (*name).into(),
+                ProfileDefaults {
+                    default_args: args.iter().map(|s| s.to_string()).collect(),
+                },
+            );
+        }
+        c
+    }
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn no_config_passthrough() {
+        let cfg = Config::default();
+        let argv = s(&["bcmr", "copy", "src", "host:dst"]);
+        assert_eq!(inject_defaults(argv.clone(), &cfg), argv);
+    }
+
+    #[test]
+    fn host_default_args_inject_after_subcommand() {
+        let cfg = cfg_with(&[("lab", &["-p", "--compress", "zstd"])], &[]);
+        let argv = s(&["bcmr", "copy", "src", "lab:dst/"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(
+            out,
+            s(&[
+                "bcmr",
+                "copy",
+                "-p",
+                "--compress",
+                "zstd",
+                "src",
+                "lab:dst/",
+            ])
+        );
+    }
+
+    #[test]
+    fn profile_via_flag_strips_then_injects() {
+        let cfg = cfg_with(&[], &[("work", &["-V", "-p"])]);
+        let argv = s(&["bcmr", "--profile", "work", "copy", "src", "dst"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(out, s(&["bcmr", "copy", "-V", "-p", "src", "dst"]));
+    }
+
+    #[test]
+    fn profile_then_host_appended_in_order() {
+        let cfg = cfg_with(&[("lab", &["--compress", "zstd"])], &[("work", &["-V"])]);
+        let argv = s(&["bcmr", "--profile", "work", "copy", "src", "lab:dst/"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(
+            out,
+            s(&[
+                "bcmr",
+                "copy",
+                "-V",
+                "--compress",
+                "zstd",
+                "src",
+                "lab:dst/",
+            ])
+        );
+    }
+
+    #[test]
+    fn unknown_profile_is_silent_no_op() {
+        let cfg = cfg_with(&[], &[("work", &["-V"])]);
+        let argv = s(&["bcmr", "--profile", "missing", "copy", "src", "dst"]);
+        let out = inject_defaults(argv, &cfg);
+        assert_eq!(out, s(&["bcmr", "copy", "src", "dst"]));
+    }
+
+    #[test]
+    fn no_subcommand_passthrough() {
+        let cfg = cfg_with(&[("lab", &["-V"])], &[]);
+        let argv = s(&["bcmr", "doctor", "lab"]);
+        assert_eq!(inject_defaults(argv.clone(), &cfg), argv);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod argv_inject;
 pub(crate) mod commands;
 pub(crate) mod completions;
 pub(crate) mod prompts;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -669,7 +669,27 @@ impl Commands {
 }
 
 pub fn parse_args() -> Cli {
-    Cli::parse()
+    let raw: Vec<String> = std::env::args().collect();
+    // CONFIG is Lazy and reads $BCMR_CONFIG; propagate --config before the
+    // first deref so host/profile defaults come from the file the user named.
+    if let Some(path) = pre_scan_config_path(&raw) {
+        std::env::set_var("BCMR_CONFIG", path);
+    }
+    let injected = crate::app::argv_inject::inject_defaults(raw, &crate::config::CONFIG);
+    Cli::parse_from(injected)
+}
+
+fn pre_scan_config_path(argv: &[String]) -> Option<String> {
+    let mut iter = argv.iter().peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--config" {
+            return iter.next().cloned();
+        }
+        if let Some(rest) = arg.strip_prefix("--config=") {
+            return Some(rest.to_string());
+        }
+    }
+    None
 }
 
 fn parse_test_mode(s: &str) -> Result<TestMode, String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,22 @@ pub struct Config {
     pub update_check: UpdateCheck,
     #[serde(default)]
     pub paths: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub host: std::collections::HashMap<String, HostDefaults>,
+    #[serde(default)]
+    pub profile: std::collections::HashMap<String, ProfileDefaults>,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct HostDefaults {
+    #[serde(default)]
+    pub default_args: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ProfileDefaults {
+    #[serde(default)]
+    pub default_args: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -163,6 +179,8 @@ impl Default for Config {
             transfer: TransferConfig::default(),
             update_check: UpdateCheck::default(),
             paths: std::collections::HashMap::new(),
+            host: std::collections::HashMap::new(),
+            profile: std::collections::HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
Closes #111.

## Summary

Builds on the path-bookmark scaffold from #107 / #112 with the two larger pieces from the original \`@bookmark\` issue: per-host default flags, and named profiles.

\`\`\`toml
[host.\"lab\"]
default_args = [\"-p\", \"--compress\", \"zstd\"]

[profile.work]
default_args = [\"-p\", \"-V\"]
\`\`\`

\`\`\`
bcmr copy ./project/ lab:dst/             # → -p --compress zstd ./project/ lab:dst/
bcmr --profile work copy x dst/           # → -p -V x dst/
BCMR_PROFILE=work bcmr copy x dst/        # → -p -V x dst/
bcmr --profile work copy x lab:dst/       # → -p -V -p --compress zstd x lab:dst/
\`\`\`

## Implementation

New pre-clap argv-injection layer in \`src/app/argv_inject.rs\`:

1. Read raw argv.
2. Look for \`--profile <name>\` / \`--profile=<name>\` / \`BCMR_PROFILE\` env.
3. Walk argv tokens, run \`parse_remote_path\` on each; **first matching host** in \`config.host\` wins.
4. Strip \`--profile\` from argv (it's not a clap flag — bcmr-internal).
5. Splice profile_args + host_args right after the subcommand name.
6. Hand the rewritten argv to clap via \`Cli::parse_from\`.

\`cli::parse_args\` also pre-scans for \`--config <PATH>\` and propagates \`BCMR_CONFIG\` *before* \`CONFIG\` is first dereferenced — without this, host/profile lookups would silently use the user's default config rather than the one they passed via \`--config\`.

## Precedence

\`explicit user flags > host defaults > profile defaults > built-in defaults\`. Achieved by ordering: profile args, then host args, then user args. clap parses left-to-right; values that come later override (boolean flags are idempotent; Vec args accumulate).

## Behaviour notes

- **Unknown \`--profile <name>\`** is a silent no-op — argv passes through with \`--profile\` stripped. Matches the forgiving stance elsewhere.
- **\`--profile\` only acts on copy/move/check/remove** — other subcommands (\`doctor\`, \`status\`, etc.) ignore it.
- **No clap surface change**: \`--profile\` is bcmr-internal, stripped before clap sees the argv. Avoids polluting every subcommand's help with a flag that only matters for the operation commands.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo test --features test-support\` — full suite green; 6 new unit tests in \`argv_inject.rs\` cover passthrough, host-only, profile-only, profile+host order, unknown profile, no subcommand
- [x] CI smoke: new \`Test profile + per-host default args\` step covers the four end-to-end scenarios (no-profile, \`--profile\`, \`BCMR_PROFILE\` env, unknown-profile no-op) using the \`verified\` suffix as the observable signal that injection actually fed clap
- [x] Live: with \`profile.verify default_args = [\"-V\"]\`, \`bcmr --profile verify copy ...\` Done line shows \`| verified\`; without \`--profile\` it doesn't; unknown profile is silent
- [x] \`docs/configuration.md\` gets new sections for per-host defaults and profiles, including the precedence rule